### PR TITLE
feat: invite system — admin-controlled registration gating

### DIFF
--- a/apps/syr/app/src/lib/components/fragments/delete-invite-code-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/delete-invite-code-dialog.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import * as Dialog from '@syr-is/ui/dialog';
+	import { Button } from '@syr-is/ui/button';
+	import { toast } from 'svelte-sonner';
+	import { Loader2 } from 'lucide-svelte';
+
+	let {
+		open = $bindable(false),
+		code = null,
+		onSuccess
+	}: {
+		open?: boolean;
+		code?: string | null;
+		onSuccess?: () => void;
+	} = $props();
+
+	let removing = $state(false);
+
+	async function handleDelete() {
+		if (!code) return;
+
+		removing = true;
+		try {
+			const res = await fetch(`/api/invite-codes/${encodeURIComponent(code)}`, {
+				method: 'DELETE'
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({}));
+				throw new Error(err?.message ?? 'Failed to delete invite code');
+			}
+			toast.success('Invite code deleted');
+			open = false;
+			onSuccess?.();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete invite code');
+		} finally {
+			removing = false;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Delete invite code</Dialog.Title>
+			<Dialog.Description>
+				Delete invite code <code class="font-mono text-xs">{code}</code>? Anyone who has this code
+				will no longer be able to use it to register.
+			</Dialog.Description>
+		</Dialog.Header>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (open = false)} disabled={removing}>Cancel</Button>
+			<Button variant="destructive" onclick={handleDelete} disabled={removing}>
+				{#if removing}
+					<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+					Deleting...
+				{:else}
+					Delete
+				{/if}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/apps/syr/app/src/lib/components/fragments/delete-invite-code-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/delete-invite-code-dialog.svelte
@@ -50,7 +50,7 @@
 		</Dialog.Header>
 		<Dialog.Footer>
 			<Button variant="outline" onclick={() => (open = false)} disabled={removing}>Cancel</Button>
-			<Button variant="destructive" onclick={handleDelete} disabled={removing}>
+			<Button variant="destructive" onclick={handleDelete} disabled={removing || !code}>
 				{#if removing}
 					<Loader2 class="mr-2 h-4 w-4 animate-spin" />
 					Deleting...

--- a/apps/syr/app/src/lib/controllers/auth.controller.ts
+++ b/apps/syr/app/src/lib/controllers/auth.controller.ts
@@ -6,7 +6,16 @@ import { identityRepository } from '$lib/repositories/identity.repository';
 import { identityController } from '$lib/controllers/identity.controller';
 import { getIdentityContext } from '$lib/server/identity-context';
 import { ensureDefaultIdentityHostUrl } from '$lib/server/ensure-default-identity-host-url.server';
-import type { UserRegistrationInput, UserLogin, User, Profile, Session } from '@syr-is/types';
+import { getRegistrationMode, INVITE_CODE_TYPE } from '$lib/instance-config';
+import { kvService } from '$lib/services/kv';
+import type {
+	UserRegistrationInput,
+	UserLogin,
+	User,
+	Profile,
+	Session,
+	InviteCodeValue
+} from '@syr-is/types';
 import type { AegisBundle } from '@syr-is/crypto/aegis';
 
 export interface RegisterResponse {
@@ -37,7 +46,42 @@ export class AuthController {
 		data: UserRegistrationInput,
 		ctx?: { ip?: string; userAgent?: string }
 	): Promise<RegisterResponse> {
-		const { username, password, display_name } = data;
+		const { username, password, display_name, invite_code } = data;
+
+		// Check registration mode
+		const mode = await getRegistrationMode();
+		if (mode === 'closed') {
+			throw new Error('Registration is closed');
+		}
+		if (mode === 'invite_only') {
+			if (!invite_code) {
+				throw new Error('Invite code required');
+			}
+			const entry = await kvService.getEntry(INVITE_CODE_TYPE, invite_code);
+			if (!entry) {
+				throw new Error('Invalid invite code');
+			}
+			const value = entry.value as InviteCodeValue;
+			if (value.max_uses !== null && value.uses >= value.max_uses) {
+				throw new Error('Invite code exhausted');
+			}
+			// Atomically redeem the code
+			try {
+				await kvService.atomicIncrementField(
+					INVITE_CODE_TYPE,
+					invite_code,
+					'uses',
+					1,
+					0,
+					value.max_uses ?? undefined
+				);
+			} catch (err) {
+				if (err instanceof Error && err.message === 'QUOTA_EXCEEDED') {
+					throw new Error('Invite code exhausted');
+				}
+				throw err;
+			}
+		}
 
 		// Check if username already exists
 		if (await userRepository.usernameExists(username)) {

--- a/apps/syr/app/src/lib/controllers/auth.controller.ts
+++ b/apps/syr/app/src/lib/controllers/auth.controller.ts
@@ -18,6 +18,25 @@ import type {
 } from '@syr-is/types';
 import type { AegisBundle } from '@syr-is/crypto/aegis';
 
+export class RegistrationClosedError extends Error {
+	readonly code = 'REGISTRATION_CLOSED';
+	constructor() {
+		super('Registration is closed');
+	}
+}
+export class InviteRequiredError extends Error {
+	readonly code = 'INVITE_REQUIRED';
+	constructor() {
+		super('Invite code required');
+	}
+}
+export class InvalidInviteCodeError extends Error {
+	readonly code = 'INVALID_INVITE_CODE';
+	constructor(message = 'Invalid invite code') {
+		super(message);
+	}
+}
+
 export interface RegisterResponse {
 	user: Omit<User, 'password_hash'>;
 	profile: Profile;
@@ -51,19 +70,27 @@ export class AuthController {
 		// Check registration mode
 		const mode = await getRegistrationMode();
 		if (mode === 'closed') {
-			throw new Error('Registration is closed');
+			throw new RegistrationClosedError();
 		}
+
+		// Check username before redeeming an invite code so we don't waste a use
+		if (await userRepository.usernameExists(username)) {
+			throw new Error('Username already exists');
+		}
+
+		// Validate and redeem invite code (after username check to avoid wasting uses)
+		let inviteRedeemed: string | null = null;
 		if (mode === 'invite_only') {
 			if (!invite_code) {
-				throw new Error('Invite code required');
+				throw new InviteRequiredError();
 			}
 			const entry = await kvService.getEntry(INVITE_CODE_TYPE, invite_code);
 			if (!entry) {
-				throw new Error('Invalid invite code');
+				throw new InvalidInviteCodeError();
 			}
 			const value = entry.value as InviteCodeValue;
 			if (value.max_uses !== null && value.uses >= value.max_uses) {
-				throw new Error('Invite code exhausted');
+				throw new InvalidInviteCodeError('Invite code exhausted');
 			}
 			// Atomically redeem the code
 			try {
@@ -75,17 +102,13 @@ export class AuthController {
 					0,
 					value.max_uses ?? undefined
 				);
+				inviteRedeemed = invite_code;
 			} catch (err) {
 				if (err instanceof Error && err.message === 'QUOTA_EXCEEDED') {
-					throw new Error('Invite code exhausted');
+					throw new InvalidInviteCodeError('Invite code exhausted');
 				}
 				throw err;
 			}
-		}
-
-		// Check if username already exists
-		if (await userRepository.usernameExists(username)) {
-			throw new Error('Username already exists');
 		}
 
 		// Hash password
@@ -122,6 +145,13 @@ export class AuthController {
 			aegisBundle = result.aegisBundle;
 		} catch (err) {
 			// Rollback: remove created user and profile so caller can retry
+			if (inviteRedeemed) {
+				try {
+					await kvService.atomicIncrementField(INVITE_CODE_TYPE, inviteRedeemed, 'uses', -1, 0);
+				} catch (e) {
+					console.error('[auth.controller] Rollback: failed to decrement invite code', e);
+				}
+			}
 			try {
 				await profileRepository.delete(profile.id);
 			} catch (e) {
@@ -156,6 +186,13 @@ export class AuthController {
 			};
 		} catch (err) {
 			// Rollback: remove identity, profile, user (unset user.did before deleting identity)
+			if (inviteRedeemed) {
+				try {
+					await kvService.atomicIncrementField(INVITE_CODE_TYPE, inviteRedeemed, 'uses', -1, 0);
+				} catch (e) {
+					console.error('[auth.controller] Rollback: failed to decrement invite code', e);
+				}
+			}
 			try {
 				await userRepository.unsetDid(user.id);
 			} catch (e) {

--- a/apps/syr/app/src/lib/instance-config.ts
+++ b/apps/syr/app/src/lib/instance-config.ts
@@ -1,10 +1,14 @@
 import { kvService } from '$lib/services/kv';
+import type { RegistrationMode } from '@syr-is/types';
 
 const INSTANCE_CONFIG_TYPE = 'instance_config';
 const KEY_PROFILE_SYNC_ASSET_PATH = 'default_profile_sync_asset_upload_path';
 const KEY_USERNAME_CHANGE_COOLDOWN_DAYS = 'username_change_cooldown_days';
+const KEY_REGISTRATION_MODE = 'registration_mode';
 const DEFAULT_PATH = ['me', 'profile', 'public'];
 const DEFAULT_USERNAME_COOLDOWN_DAYS = 7;
+const DEFAULT_REGISTRATION_MODE: RegistrationMode = 'open';
+const INVITE_CODE_TYPE = 'invite_code';
 
 /**
  * Get the profile sync asset upload path from instance config.
@@ -38,10 +42,23 @@ export async function getUsernameChangeCooldownDays(): Promise<number> {
 	return DEFAULT_USERNAME_COOLDOWN_DAYS;
 }
 
+/**
+ * Get the registration mode for this instance.
+ * Default: 'open' when unset or invalid.
+ */
+export async function getRegistrationMode(): Promise<RegistrationMode> {
+	const val = await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_REGISTRATION_MODE);
+	if (val === 'open' || val === 'invite_only' || val === 'closed') return val;
+	return DEFAULT_REGISTRATION_MODE;
+}
+
 export {
 	INSTANCE_CONFIG_TYPE,
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
+	KEY_REGISTRATION_MODE,
 	DEFAULT_PATH,
-	DEFAULT_USERNAME_COOLDOWN_DAYS
+	DEFAULT_USERNAME_COOLDOWN_DAYS,
+	DEFAULT_REGISTRATION_MODE,
+	INVITE_CODE_TYPE
 };

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
@@ -6,9 +6,12 @@ import {
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	DEFAULT_PATH,
-	DEFAULT_USERNAME_COOLDOWN_DAYS
+	DEFAULT_USERNAME_COOLDOWN_DAYS,
+	INVITE_CODE_TYPE
 } from '$lib/instance-config';
+import { getRegistrationMode } from '$lib/instance-config';
 import { instanceDiscoveryRegistryRepository } from '$lib/repositories/instance-discovery-registry.repository';
+import type { InviteCodeValue } from '@syr-is/types';
 
 export const load: PageServerLoad = async ({ parent }) => {
 	const { user } = await parent();
@@ -23,12 +26,31 @@ export const load: PageServerLoad = async ({ parent }) => {
 		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_USERNAME_CHANGE_COOLDOWN_DAYS)) ??
 		String(DEFAULT_USERNAME_COOLDOWN_DAYS);
 
+	const registrationMode = await getRegistrationMode();
+
+	const inviteCodeEntries = await kvService.getByType(INVITE_CODE_TYPE);
+	const inviteCodes = inviteCodeEntries.map((entry) => {
+		const raw = String(entry.id.id);
+		const prefix = `${INVITE_CODE_TYPE}:`;
+		const code = raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+		const value = entry.value as InviteCodeValue;
+		return {
+			code,
+			created_by: value.created_by,
+			max_uses: value.max_uses,
+			uses: value.uses,
+			created_at: value.created_at
+		};
+	});
+
 	const instanceDiscoveryRows = await instanceDiscoveryRegistryRepository.findAll();
 
 	return {
 		user,
 		profileSyncAssetPath,
 		usernameCooldownDays,
+		registrationMode,
+		inviteCodes,
 		instanceDiscoveryRegistries: instanceDiscoveryRows.map((r) => ({
 			id: r.id.toString(),
 			registryUrl: r.registry_url

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
@@ -11,7 +11,7 @@ import {
 } from '$lib/instance-config';
 import { getRegistrationMode } from '$lib/instance-config';
 import { instanceDiscoveryRegistryRepository } from '$lib/repositories/instance-discovery-registry.repository';
-import type { InviteCodeValue } from '@syr-is/types';
+import { InviteCodeValueSchema } from '@syr-is/types';
 
 export const load: PageServerLoad = async ({ parent }) => {
 	const { user } = await parent();
@@ -29,19 +29,30 @@ export const load: PageServerLoad = async ({ parent }) => {
 	const registrationMode = await getRegistrationMode();
 
 	const inviteCodeEntries = await kvService.getByType(INVITE_CODE_TYPE);
-	const inviteCodes = inviteCodeEntries.map((entry) => {
+	const inviteCodes: {
+		code: string;
+		created_by: string;
+		max_uses: number | null;
+		uses: number;
+		created_at: string;
+	}[] = [];
+	for (const entry of inviteCodeEntries) {
 		const raw = String(entry.id.id);
 		const prefix = `${INVITE_CODE_TYPE}:`;
 		const code = raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
-		const value = entry.value as InviteCodeValue;
-		return {
+		const parsed = InviteCodeValueSchema.safeParse(entry.value);
+		if (!parsed.success) {
+			console.warn(`[instance-config] Skipping malformed invite code entry ${raw}`, parsed.error);
+			continue;
+		}
+		inviteCodes.push({
 			code,
-			created_by: value.created_by,
-			max_uses: value.max_uses,
-			uses: value.uses,
-			created_at: value.created_at
-		};
-	});
+			created_by: parsed.data.created_by,
+			max_uses: parsed.data.max_uses,
+			uses: parsed.data.uses,
+			created_at: parsed.data.created_at
+		});
+	}
 
 	const instanceDiscoveryRows = await instanceDiscoveryRegistryRepository.findAll();
 

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
@@ -2,10 +2,13 @@
 	import * as Card from '@syr-is/ui/card';
 	import { Input } from '@syr-is/ui/input';
 	import { Button, buttonVariants } from '@syr-is/ui/button';
+	import * as Select from '@syr-is/ui/select';
 	import { toast } from 'svelte-sonner';
 	import { invalidateAll } from '$app/navigation';
 	import type { PageData } from './$types';
 	import RemoveDiscoveryRegistryDialog from '$lib/components/fragments/remove-discovery-registry-dialog.svelte';
+	import DeleteInviteCodeDialog from '$lib/components/fragments/delete-invite-code-dialog.svelte';
+	import { Copy } from 'lucide-svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -13,6 +16,14 @@
 	let usernameCooldownDays = $state('');
 	let pathLoading = $state(false);
 	let cooldownLoading = $state(false);
+
+	let registrationMode = $state('open');
+	let registrationModeLoading = $state(false);
+
+	let newCodeMaxUses = $state<number | null>(null);
+	let creatingCode = $state(false);
+	let deleteCodeDialogOpen = $state(false);
+	let codeToDelete = $state<string | null>(null);
 
 	let newInstanceRegistryUrl = $state('');
 	let addingInstanceRegistry = $state(false);
@@ -22,6 +33,7 @@
 	$effect(() => {
 		profileSyncAssetPath = data.profileSyncAssetPath;
 		usernameCooldownDays = data.usernameCooldownDays;
+		registrationMode = data.registrationMode;
 	});
 
 	async function saveProfileSyncPath() {
@@ -101,6 +113,70 @@
 		}
 	}
 
+	async function saveRegistrationMode() {
+		registrationModeLoading = true;
+		try {
+			const res = await fetch('/api/instance-config/registration_mode', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: registrationMode })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to update');
+				return;
+			}
+			toast.success('Registration mode updated');
+			await invalidateAll();
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to update');
+		} finally {
+			registrationModeLoading = false;
+		}
+	}
+
+	async function createInviteCode() {
+		creatingCode = true;
+		try {
+			const maxUses = newCodeMaxUses != null && newCodeMaxUses >= 1 ? newCodeMaxUses : null;
+			if (newCodeMaxUses != null && (isNaN(newCodeMaxUses) || newCodeMaxUses < 1)) {
+				toast.error('Max uses must be a positive number');
+				return;
+			}
+			const res = await fetch('/api/invite-codes', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ max_uses: maxUses })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to create invite code');
+				return;
+			}
+			newCodeMaxUses = null;
+			toast.success(`Invite code created: ${json.data.code}`);
+			await invalidateAll();
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to create invite code');
+		} finally {
+			creatingCode = false;
+		}
+	}
+
+	async function copyCode(code: string) {
+		try {
+			await navigator.clipboard.writeText(code);
+			toast.success('Copied to clipboard');
+		} catch {
+			toast.error('Failed to copy');
+		}
+	}
+
+	function openDeleteCode(code: string) {
+		codeToDelete = code;
+		deleteCodeDialogOpen = true;
+	}
+
 	function openRemoveInstance(reg: { id: string; registryUrl: string }) {
 		instanceRegistryToRemove = reg;
 		removeInstanceDialogOpen = true;
@@ -112,6 +188,99 @@
 </svelte:head>
 
 <div class="mx-auto max-w-2xl space-y-6">
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Registration mode</Card.Title>
+			<Card.Description>Control who can create accounts on this instance.</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="flex gap-2">
+				<Select.Root type="single" bind:value={registrationMode}>
+					<Select.Trigger class="w-full" aria-label="Registration mode">
+						{registrationMode === 'open'
+							? 'Open — anyone can register'
+							: registrationMode === 'invite_only'
+								? 'Invite only — requires an invite code'
+								: 'Closed — no new registrations'}
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="open">Open — anyone can register</Select.Item>
+						<Select.Item value="invite_only">Invite only — requires an invite code</Select.Item>
+						<Select.Item value="closed">Closed — no new registrations</Select.Item>
+					</Select.Content>
+				</Select.Root>
+				<Button onclick={saveRegistrationMode} disabled={registrationModeLoading}>
+					{registrationModeLoading ? 'Saving…' : 'Save'}
+				</Button>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	{#if registrationMode === 'invite_only'}
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Invite codes</Card.Title>
+				<Card.Description>
+					Create and manage invite codes for new user registration. Each code can optionally be
+					limited to a maximum number of uses.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="flex flex-col gap-2 sm:flex-row sm:items-end">
+					<div class="flex min-w-0 flex-1 flex-col gap-1">
+						<label for="invite-max-uses" class="text-sm font-medium">Max uses (optional)</label>
+						<Input
+							id="invite-max-uses"
+							type="number"
+							min={1}
+							bind:value={newCodeMaxUses}
+							placeholder="Unlimited"
+						/>
+					</div>
+					<Button onclick={createInviteCode} disabled={creatingCode}>
+						{creatingCode ? 'Creating…' : 'Create code'}
+					</Button>
+				</div>
+				{#if data.inviteCodes?.length}
+					<ul class="space-y-2">
+						{#each data.inviteCodes as invite (invite.code)}
+							<li
+								class="flex flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+							>
+								<div class="flex flex-col gap-0.5">
+									<div class="flex items-center gap-2">
+										<code class="font-mono text-xs">{invite.code}</code>
+										<button
+											type="button"
+											class="text-muted-foreground hover:text-foreground"
+											onclick={() => copyCode(invite.code)}
+											aria-label="Copy invite code"
+										>
+											<Copy class="h-3.5 w-3.5" />
+										</button>
+									</div>
+									<span class="text-xs text-muted-foreground">
+										{invite.uses}{invite.max_uses !== null ? `/${invite.max_uses}` : ''} uses &middot;
+										by {invite.created_by}
+									</span>
+								</div>
+								<button
+									type="button"
+									class={buttonVariants({ variant: 'destructive', size: 'sm' })}
+									onclick={() => openDeleteCode(invite.code)}
+								>
+									Delete
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{:else}
+					<p class="text-sm text-muted-foreground">No invite codes yet.</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
 	<Card.Root>
 		<Card.Header>
 			<Card.Title>Default profile sync asset upload path</Card.Title>
@@ -215,6 +384,12 @@
 		</Card.Content>
 	</Card.Root>
 </div>
+
+<DeleteInviteCodeDialog
+	bind:open={deleteCodeDialogOpen}
+	code={codeToDelete}
+	onSuccess={() => invalidateAll()}
+/>
 
 <RemoveDiscoveryRegistryDialog
 	bind:open={removeInstanceDialogOpen}

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
@@ -17,7 +17,8 @@
 	let pathLoading = $state(false);
 	let cooldownLoading = $state(false);
 
-	let registrationMode = $state('open');
+	let registrationModeDraft = $state('open');
+	let registrationModePersisted = $state('open');
 	let registrationModeLoading = $state(false);
 
 	let newCodeMaxUses = $state<number | null>(null);
@@ -33,7 +34,8 @@
 	$effect(() => {
 		profileSyncAssetPath = data.profileSyncAssetPath;
 		usernameCooldownDays = data.usernameCooldownDays;
-		registrationMode = data.registrationMode;
+		registrationModeDraft = data.registrationMode;
+		registrationModePersisted = data.registrationMode;
 	});
 
 	async function saveProfileSyncPath() {
@@ -119,16 +121,19 @@
 			const res = await fetch('/api/instance-config/registration_mode', {
 				method: 'PATCH',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ value: registrationMode })
+				body: JSON.stringify({ value: registrationModeDraft })
 			});
 			const json = await res.json();
 			if (!res.ok) {
+				registrationModeDraft = registrationModePersisted;
 				toast.error(json.message ?? 'Failed to update');
 				return;
 			}
+			registrationModePersisted = registrationModeDraft;
 			toast.success('Registration mode updated');
 			await invalidateAll();
 		} catch (e) {
+			registrationModeDraft = registrationModePersisted;
 			toast.error(e instanceof Error ? e.message : 'Failed to update');
 		} finally {
 			registrationModeLoading = false;
@@ -195,11 +200,11 @@
 		</Card.Header>
 		<Card.Content class="space-y-4">
 			<div class="flex gap-2">
-				<Select.Root type="single" bind:value={registrationMode}>
+				<Select.Root type="single" bind:value={registrationModeDraft}>
 					<Select.Trigger class="w-full" aria-label="Registration mode">
-						{registrationMode === 'open'
+						{registrationModeDraft === 'open'
 							? 'Open — anyone can register'
-							: registrationMode === 'invite_only'
+							: registrationModeDraft === 'invite_only'
 								? 'Invite only — requires an invite code'
 								: 'Closed — no new registrations'}
 					</Select.Trigger>
@@ -216,7 +221,7 @@
 		</Card.Content>
 	</Card.Root>
 
-	{#if registrationMode === 'invite_only'}
+	{#if registrationModePersisted === 'invite_only'}
 		<Card.Root>
 			<Card.Header>
 				<Card.Title>Invite codes</Card.Title>

--- a/apps/syr/app/src/routes/api/auth/register/+server.ts
+++ b/apps/syr/app/src/routes/api/auth/register/+server.ts
@@ -53,7 +53,27 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
 		}
 
 		if (err instanceof Error) {
-			// Handle specific errors
+			if (err.message === 'Registration is closed') {
+				throw error(403, {
+					code: 'FORBIDDEN',
+					message: 'Registration is currently closed on this instance'
+				});
+			}
+
+			if (err.message === 'Invite code required') {
+				throw error(400, {
+					code: 'INVITE_REQUIRED',
+					message: 'An invite code is required to register on this instance'
+				});
+			}
+
+			if (err.message === 'Invalid invite code' || err.message === 'Invite code exhausted') {
+				throw error(400, {
+					code: 'INVALID_INVITE_CODE',
+					message: err.message
+				});
+			}
+
 			if (err.message.includes('already exists')) {
 				throw error(409, {
 					code: 'CONFLICT',

--- a/apps/syr/app/src/routes/api/auth/register/+server.ts
+++ b/apps/syr/app/src/routes/api/auth/register/+server.ts
@@ -1,7 +1,12 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { UserRegistrationInputSchema } from '@syr-is/types';
-import { authController } from '$lib/controllers/auth.controller';
+import {
+	authController,
+	RegistrationClosedError,
+	InviteRequiredError,
+	InvalidInviteCodeError
+} from '$lib/controllers/auth.controller';
 import { config } from '$lib/config';
 import { z } from 'zod';
 
@@ -52,28 +57,28 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
 			});
 		}
 
+		if (err instanceof RegistrationClosedError) {
+			throw error(403, {
+				code: 'FORBIDDEN',
+				message: 'Registration is currently closed on this instance'
+			});
+		}
+
+		if (err instanceof InviteRequiredError) {
+			throw error(400, {
+				code: 'INVITE_REQUIRED',
+				message: 'An invite code is required to register on this instance'
+			});
+		}
+
+		if (err instanceof InvalidInviteCodeError) {
+			throw error(400, {
+				code: 'INVALID_INVITE_CODE',
+				message: err.message
+			});
+		}
+
 		if (err instanceof Error) {
-			if (err.message === 'Registration is closed') {
-				throw error(403, {
-					code: 'FORBIDDEN',
-					message: 'Registration is currently closed on this instance'
-				});
-			}
-
-			if (err.message === 'Invite code required') {
-				throw error(400, {
-					code: 'INVITE_REQUIRED',
-					message: 'An invite code is required to register on this instance'
-				});
-			}
-
-			if (err.message === 'Invalid invite code' || err.message === 'Invite code exhausted') {
-				throw error(400, {
-					code: 'INVALID_INVITE_CODE',
-					message: err.message
-				});
-			}
-
 			if (err.message.includes('already exists')) {
 				throw error(409, {
 					code: 'CONFLICT',

--- a/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
+++ b/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
@@ -6,12 +6,15 @@ import {
 	INSTANCE_CONFIG_TYPE,
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
+	KEY_REGISTRATION_MODE,
 	DEFAULT_PATH
 } from '$lib/instance-config';
+import { RegistrationModeSchema } from '@syr-is/types';
 
 const INSTANCE_CONFIG_KEYS = [
 	KEY_PROFILE_SYNC_ASSET_PATH,
-	KEY_USERNAME_CHANGE_COOLDOWN_DAYS
+	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
+	KEY_REGISTRATION_MODE
 ] as const;
 type AllowedKey = (typeof INSTANCE_CONFIG_KEYS)[number];
 
@@ -40,6 +43,15 @@ function validateCooldownDaysValue(val: string): string {
 		throw new Error('Value must be an integer between 1 and 365');
 	}
 	return String(n);
+}
+
+/** Validate registration mode: open | invite_only | closed */
+function validateRegistrationMode(val: string): string {
+	const result = RegistrationModeSchema.safeParse(val.trim());
+	if (!result.success) {
+		throw new Error('Value must be one of: open, invite_only, closed');
+	}
+	return result.data;
 }
 
 export const GET: RequestHandler = async ({ params, locals }) => {
@@ -82,6 +94,8 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	try {
 		if (key === KEY_USERNAME_CHANGE_COOLDOWN_DAYS) {
 			value = validateCooldownDaysValue(body.value);
+		} else if (key === KEY_REGISTRATION_MODE) {
+			value = validateRegistrationMode(body.value);
 		} else {
 			value = validatePathValue(body.value);
 		}

--- a/apps/syr/app/src/routes/api/invite-codes/+server.ts
+++ b/apps/syr/app/src/routes/api/invite-codes/+server.ts
@@ -1,0 +1,95 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { kvService } from '$lib/services/kv';
+import { INVITE_CODE_TYPE } from '$lib/instance-config';
+import type { InviteCodeValue } from '@syr-is/types';
+
+function generateInviteCode(): string {
+	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	const bytes = new Uint8Array(8);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, (b) => chars[b % chars.length]).join('');
+}
+
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage invite codes'
+		});
+	}
+
+	const entries = await kvService.getByType(INVITE_CODE_TYPE);
+	const codes = entries.map((entry) => {
+		const raw = String(entry.id.id);
+		const prefix = `${INVITE_CODE_TYPE}:`;
+		const value = entry.value as InviteCodeValue;
+		return {
+			code: raw.startsWith(prefix) ? raw.slice(prefix.length) : raw,
+			created_by: value.created_by,
+			max_uses: value.max_uses,
+			uses: value.uses,
+			created_at: value.created_at
+		};
+	});
+
+	return json({ status: 'success', data: codes });
+};
+
+const CreateBodySchema = z.object({
+	max_uses: z.number().int().min(1).nullable().optional()
+});
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage invite codes'
+		});
+	}
+
+	let body: z.infer<typeof CreateBodySchema>;
+	try {
+		body = CreateBodySchema.parse(await request.json());
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid request body' });
+	}
+
+	const username = locals.user.username;
+	let code = generateInviteCode();
+
+	const value: InviteCodeValue = {
+		created_by: username,
+		max_uses: body.max_uses ?? null,
+		uses: 0,
+		created_at: new Date().toISOString()
+	};
+
+	// Create with one retry on collision
+	let created = await kvService.createIfAbsent(INVITE_CODE_TYPE, code, value);
+	if (!created) {
+		code = generateInviteCode();
+		created = await kvService.createIfAbsent(INVITE_CODE_TYPE, code, value);
+		if (!created) {
+			throw error(500, {
+				code: 'INTERNAL_SERVER_ERROR',
+				message: 'Failed to generate unique invite code'
+			});
+		}
+	}
+
+	return json(
+		{
+			status: 'success',
+			data: { code, ...value }
+		},
+		{ status: 201 }
+	);
+};

--- a/apps/syr/app/src/routes/api/invite-codes/[code]/+server.ts
+++ b/apps/syr/app/src/routes/api/invite-codes/[code]/+server.ts
@@ -44,6 +44,11 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 		});
 	}
 
+	const exists = await kvService.has(INVITE_CODE_TYPE, params.code);
+	if (!exists) {
+		throw error(404, { code: 'NOT_FOUND', message: 'Invite code not found' });
+	}
+
 	await kvService.delete(INVITE_CODE_TYPE, params.code);
 	return json({ status: 'success' });
 };

--- a/apps/syr/app/src/routes/api/invite-codes/[code]/+server.ts
+++ b/apps/syr/app/src/routes/api/invite-codes/[code]/+server.ts
@@ -1,0 +1,49 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { kvService } from '$lib/services/kv';
+import { INVITE_CODE_TYPE } from '$lib/instance-config';
+import type { InviteCodeValue } from '@syr-is/types';
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage invite codes'
+		});
+	}
+
+	const entry = await kvService.getEntry(INVITE_CODE_TYPE, params.code);
+	if (!entry) {
+		throw error(404, { code: 'NOT_FOUND', message: 'Invite code not found' });
+	}
+
+	const value = entry.value as InviteCodeValue;
+	return json({
+		status: 'success',
+		data: {
+			code: params.code,
+			created_by: value.created_by,
+			max_uses: value.max_uses,
+			uses: value.uses,
+			created_at: value.created_at
+		}
+	});
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage invite codes'
+		});
+	}
+
+	await kvService.delete(INVITE_CODE_TYPE, params.code);
+	return json({ status: 'success' });
+};

--- a/apps/syr/app/src/routes/register/+page.server.ts
+++ b/apps/syr/app/src/routes/register/+page.server.ts
@@ -1,0 +1,11 @@
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { getRegistrationMode } from '$lib/instance-config';
+
+export const load: PageServerLoad = async () => {
+	const registrationMode = await getRegistrationMode();
+	if (registrationMode === 'closed') {
+		throw redirect(303, '/login');
+	}
+	return { registrationMode };
+};

--- a/apps/syr/app/src/routes/register/+page.svelte
+++ b/apps/syr/app/src/routes/register/+page.svelte
@@ -21,6 +21,11 @@
 
 			const { confirmPassword: _, ...registrationData } = form.data;
 
+			if (inviteOnly && !registrationData.invite_code?.trim()) {
+				toast.error('An invite code is required to register');
+				return;
+			}
+
 			try {
 				const response = await fetch('/api/auth/register', {
 					method: 'POST',
@@ -62,6 +67,7 @@
 									{...props}
 									bind:value={$formData.invite_code}
 									placeholder="Enter your invite code"
+									required
 								/>
 							{/snippet}
 						</Form.Control>

--- a/apps/syr/app/src/routes/register/+page.svelte
+++ b/apps/syr/app/src/routes/register/+page.svelte
@@ -7,6 +7,10 @@
 	import * as Card from '@syr-is/ui/card';
 	import { resolve } from '$app/paths';
 	import { toast } from 'svelte-sonner';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+	const inviteOnly = $derived(data.registrationMode === 'invite_only');
 
 	const form = superForm(defaults(zod4(UserRegistrationSchema)), {
 		validators: zod4(UserRegistrationSchema),
@@ -49,6 +53,23 @@
 		</Card.Header>
 		<form method="POST" use:enhance>
 			<Card.Content class="space-y-4">
+				{#if inviteOnly}
+					<Form.Field {form} name="invite_code">
+						<Form.Control>
+							{#snippet children({ props })}
+								<Form.Label>Invite Code</Form.Label>
+								<Input
+									{...props}
+									bind:value={$formData.invite_code}
+									placeholder="Enter your invite code"
+								/>
+							{/snippet}
+						</Form.Control>
+						<Form.Description>This instance requires an invite code to register.</Form.Description>
+						<Form.FieldErrors />
+					</Form.Field>
+				{/if}
+
 				<Form.Field {form} name="username">
 					<Form.Control>
 						{#snippet children({ props })}

--- a/packages/ts/types/src/user.ts
+++ b/packages/ts/types/src/user.ts
@@ -18,6 +18,13 @@ export const UserRoleSchema = z.enum(['ADMIN', 'USER']);
 export type UserRole = z.infer<typeof UserRoleSchema>;
 
 /**
+ * Registration Mode Schema
+ * Controls who can create accounts on this instance
+ */
+export const RegistrationModeSchema = z.enum(['open', 'invite_only', 'closed']);
+export type RegistrationMode = z.infer<typeof RegistrationModeSchema>;
+
+/**
  * User Schema
  * Represents a user account in the SYR system
  * Designed for sovereignty - username and DID only, no email
@@ -88,7 +95,13 @@ export const UserRegistrationInputSchema = z.object({
 		.regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
 		.regex(/[a-z]/, 'Password must contain at least one lowercase letter')
 		.regex(/[0-9]/, 'Password must contain at least one number'),
-	display_name: z.string().min(1).max(100)
+	display_name: z.string().min(1).max(100),
+	invite_code: z
+		.string()
+		.min(1)
+		.max(32)
+		.regex(/^[a-zA-Z0-9]+$/, 'Invite code must be alphanumeric')
+		.optional()
 });
 
 export type UserRegistrationInput = z.infer<typeof UserRegistrationInputSchema>;
@@ -103,6 +116,19 @@ export const UserRegistrationSchema = UserRegistrationInputSchema.extend({
 	message: 'Passwords do not match',
 	path: ['confirmPassword']
 });
+
+/**
+ * Invite Code Value Schema
+ * The value stored in the KV store for each invite code
+ */
+export const InviteCodeValueSchema = z.object({
+	created_by: z.string(),
+	max_uses: z.number().int().min(1).nullable(),
+	uses: z.number().int().min(0),
+	created_at: z.string()
+});
+
+export type InviteCodeValue = z.infer<typeof InviteCodeValueSchema>;
 
 export type UserRegistration = z.infer<typeof UserRegistrationSchema>;
 


### PR DESCRIPTION
## Summary

Closes #36

- Adds registration mode (`open` / `invite_only` / `closed`) as an instance config setting
- Admin CRUD API for invite codes (`/api/invite-codes`) with atomic redemption via KV store
- Registration gate in auth controller — rejects closed, validates + redeems codes for invite-only
- Admin UI: registration mode selector (shadcn Select) and invite code management (create, list, copy, delete)
- Registration form conditionally shows invite code field; redirects to `/login` when closed

## Test plan

- [ ] Set registration mode to `closed` — verify `/register` redirects to `/login`, API returns 403
- [ ] Set to `invite_only` — verify registration without code returns 400, invalid code returns 400, valid code succeeds and increments uses
- [ ] Create code with `max_uses: 1` — redeem once (success), attempt again (fail with exhausted)
- [ ] Set to `open` — verify registration works as before (no invite code needed)
- [ ] Admin UI: create/list/copy/delete codes, toggle between modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration mode control: admins can set registration to open, invite-only, or closed.
  * Invite code management (admin): create, list, copy, and delete invite codes from settings with success/error feedback.
  * Invite-only registration: users see an invite-code field and client-side validation when invite-only is enabled; closed mode redirects to login.
* **UX**
  * Confirmation dialog and toasts for invite-code deletion and creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->