### PR TITLE
feat: admin user management panel (#37)

### DIFF
--- a/apps/syr/app/src/lib/components/fragments/admin-delete-post-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/admin-delete-post-dialog.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import * as Dialog from '@syr-is/ui/dialog';
+	import { Button } from '@syr-is/ui/button';
+	import { toast } from 'svelte-sonner';
+	import { Loader2 } from 'lucide-svelte';
+
+	let {
+		open = $bindable(false),
+		userId = null,
+		postDid = null,
+		postLocalId = null,
+		postTitle = null,
+		onSuccess
+	}: {
+		open?: boolean;
+		userId?: string | null;
+		postDid?: string | null;
+		postLocalId?: string | null;
+		postTitle?: string | null;
+		onSuccess?: () => void;
+	} = $props();
+
+	let deleting = $state(false);
+
+	async function handleDelete() {
+		if (!userId || !postDid || !postLocalId) return;
+
+		deleting = true;
+		try {
+			const res = await fetch(
+				`/api/admin/users/${encodeURIComponent(userId)}/posts/${encodeURIComponent(postDid)}/${encodeURIComponent(postLocalId)}`,
+				{ method: 'DELETE' }
+			);
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({}));
+				throw new Error(err?.message ?? 'Failed to delete post');
+			}
+			toast.success('Post deleted');
+			open = false;
+			onSuccess?.();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete post');
+		} finally {
+			deleting = false;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Delete post</Dialog.Title>
+			<Dialog.Description>
+				Delete {postTitle ? `"${postTitle}"` : 'this post'}? The post record will be removed but
+				associated uploads will be preserved.
+			</Dialog.Description>
+		</Dialog.Header>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (open = false)} disabled={deleting}>Cancel</Button>
+			<Button
+				variant="destructive"
+				onclick={handleDelete}
+				disabled={deleting || !postDid || !postLocalId}
+			>
+				{#if deleting}
+					<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+					Deleting…
+				{:else}
+					Delete
+				{/if}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/apps/syr/app/src/lib/components/fragments/admin-delete-upload-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/admin-delete-upload-dialog.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import * as Dialog from '@syr-is/ui/dialog';
+	import { Button } from '@syr-is/ui/button';
+	import { toast } from 'svelte-sonner';
+	import { Loader2 } from 'lucide-svelte';
+
+	let {
+		open = $bindable(false),
+		userId = null,
+		uploadDid = null,
+		uploadLocalId = null,
+		filename = null,
+		onSuccess
+	}: {
+		open?: boolean;
+		userId?: string | null;
+		uploadDid?: string | null;
+		uploadLocalId?: string | null;
+		filename?: string | null;
+		onSuccess?: () => void;
+	} = $props();
+
+	let deleting = $state(false);
+
+	async function handleDelete() {
+		if (!userId || !uploadDid || !uploadLocalId) return;
+
+		deleting = true;
+		try {
+			const res = await fetch(
+				`/api/admin/users/${encodeURIComponent(userId)}/uploads/${encodeURIComponent(uploadDid)}/${encodeURIComponent(uploadLocalId)}`,
+				{ method: 'DELETE' }
+			);
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({}));
+				throw new Error(err?.message ?? 'Failed to delete upload');
+			}
+			toast.success('Upload deleted');
+			open = false;
+			onSuccess?.();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete upload');
+		} finally {
+			deleting = false;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Delete upload</Dialog.Title>
+			<Dialog.Description>
+				Delete {filename ? `"${filename}"` : 'this upload'}? The file will be permanently removed
+				from storage.
+			</Dialog.Description>
+		</Dialog.Header>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (open = false)} disabled={deleting}>Cancel</Button>
+			<Button
+				variant="destructive"
+				onclick={handleDelete}
+				disabled={deleting || !uploadDid || !uploadLocalId}
+			>
+				{#if deleting}
+					<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+					Deleting…
+				{:else}
+					Delete
+				{/if}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/apps/syr/app/src/lib/components/fragments/admin-delete-user-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/admin-delete-user-dialog.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import * as Dialog from '@syr-is/ui/dialog';
+	import { Button } from '@syr-is/ui/button';
+	import { Input } from '@syr-is/ui/input';
+	import { toast } from 'svelte-sonner';
+	import { Loader2 } from 'lucide-svelte';
+
+	let {
+		open = $bindable(false),
+		userId = null,
+		username = null,
+		onSuccess
+	}: {
+		open?: boolean;
+		userId?: string | null;
+		username?: string | null;
+		onSuccess?: () => void;
+	} = $props();
+
+	let confirmText = $state('');
+	let deleting = $state(false);
+
+	const confirmed = $derived(confirmText === username);
+
+	$effect(() => {
+		if (!open) confirmText = '';
+	});
+
+	async function handleDelete() {
+		if (!userId || !confirmed) return;
+
+		deleting = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}`, {
+				method: 'DELETE'
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({}));
+				throw new Error(err?.message ?? 'Failed to delete user');
+			}
+			toast.success(`User ${username} deleted`);
+			open = false;
+			onSuccess?.();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete user');
+		} finally {
+			deleting = false;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Delete user account</Dialog.Title>
+			<Dialog.Description>
+				This will permanently delete all data for <strong>{username}</strong> including their posts,
+				uploads, identity, and profile. This action cannot be undone.
+			</Dialog.Description>
+		</Dialog.Header>
+		<div class="space-y-2 py-2">
+			<label for="confirm-username" class="text-sm font-medium">
+				Type <strong>{username}</strong> to confirm
+			</label>
+			<Input id="confirm-username" bind:value={confirmText} placeholder={username ?? ''} />
+		</div>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (open = false)} disabled={deleting}>Cancel</Button>
+			<Button variant="destructive" onclick={handleDelete} disabled={deleting || !confirmed}>
+				{#if deleting}
+					<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+					Deleting…
+				{:else}
+					Delete account
+				{/if}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/apps/syr/app/src/lib/components/fragments/file-browser.svelte
+++ b/apps/syr/app/src/lib/components/fragments/file-browser.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+	import * as Select from '@syr-is/ui/select';
+	import * as Pagination from '@syr-is/ui/pagination';
+	import * as Card from '@syr-is/ui/card';
+	import { Button } from '@syr-is/ui/button';
+	import { Skeleton } from '@syr-is/ui/skeleton';
+	import { ChevronRight, Home, File } from 'lucide-svelte';
+	import ViewModeToggle from '$lib/components/fragments/view-mode-toggle.svelte';
+	import FileTable from '$lib/components/fragments/file-table.svelte';
+	import FileGrid from '$lib/components/fragments/file-grid.svelte';
+	import FileCarousel from '$lib/components/fragments/file-carousel.svelte';
+	import MediaCardGrid from '$lib/components/fragments/media-card-grid.svelte';
+	import FolderCard from '$lib/components/fragments/folder-card.svelte';
+	import {
+		type ViewMode,
+		type DisplayItem,
+		uploadsToDisplayItems,
+		getFileItems
+	} from '$lib/types/display-item';
+	import type { UploadWithCompositeId, Folder } from '@syr-is/types';
+	import type { Snippet } from 'svelte';
+
+	let {
+		folders = [],
+		uploads = [],
+		breadcrumbs = [],
+		loading = false,
+		error = null,
+		total = 0,
+		viewMode = $bindable<ViewMode>('list'),
+		currentPage = $bindable(1),
+		limit = $bindable(20),
+		sortField = $bindable<'created_at' | 'updated_at' | 'filename' | 'size'>('created_at'),
+		sortOrder = $bindable<'asc' | 'desc'>('desc'),
+		readonly = false,
+		actions,
+		onNavigateFolder,
+		onDeleteUpload,
+		onDeleteFolder,
+		onPreview,
+		onDownload,
+		onCopyLink,
+		onRename,
+		onMove
+	}: {
+		folders?: Folder[];
+		uploads?: UploadWithCompositeId[];
+		breadcrumbs?: Array<{ id: string; name: string }>;
+		loading?: boolean;
+		error?: string | null;
+		total?: number;
+		viewMode?: ViewMode;
+		currentPage?: number;
+		limit?: number;
+		sortField?: 'created_at' | 'updated_at' | 'filename' | 'size';
+		sortOrder?: 'asc' | 'desc';
+		readonly?: boolean;
+		actions?: Snippet;
+		onNavigateFolder?: (folderId: string | null) => void;
+		onDeleteUpload?: (upload: UploadWithCompositeId) => void;
+		onDeleteFolder?: (folder: Folder) => void;
+		onPreview?: (item: DisplayItem, index: number) => void;
+		onDownload?: (upload: UploadWithCompositeId) => void;
+		onCopyLink?: (upload: UploadWithCompositeId) => void;
+		onRename?: (upload: UploadWithCompositeId) => void;
+		onMove?: (upload: UploadWithCompositeId) => void;
+	} = $props();
+
+	const displayItems = $derived(uploadsToDisplayItems(folders, uploads));
+	const fileDisplayItems = $derived(getFileItems(displayItems));
+	const totalPages = $derived(Math.ceil(total / limit));
+
+	function isPublicFolder(folder: Folder): boolean {
+		return folder.name.toLowerCase() === 'public';
+	}
+
+	function handleFolderClick(folder: Folder) {
+		const id = typeof folder.id === 'string' ? folder.id : folder.id.toString();
+		onNavigateFolder?.(id);
+	}
+
+	function handleFolderDelete(folder: Folder) {
+		onDeleteFolder?.(folder);
+	}
+
+	function handleTablePreview(item: DisplayItem) {
+		if (item.kind !== 'file') return;
+		const index = fileDisplayItems.findIndex((di) => di.id === item.id);
+		if (index >= 0) onPreview?.(item, index);
+	}
+
+	function handleTableDownload(item: DisplayItem) {
+		if (item.kind === 'file') onDownload?.(item.data);
+	}
+
+	function handleTableCopyLink(item: DisplayItem) {
+		if (item.kind === 'file') onCopyLink?.(item.data);
+	}
+
+	function handleTableRename(item: DisplayItem) {
+		if (item.kind === 'file') onRename?.(item.data);
+	}
+
+	function handleTableMove(item: DisplayItem) {
+		if (item.kind === 'file') onMove?.(item.data);
+	}
+
+	function handleTableDelete(item: DisplayItem) {
+		if (item.kind === 'file') onDeleteUpload?.(item.data);
+	}
+
+	function handleGridItemClick(index: number) {
+		const item = fileDisplayItems[index];
+		if (item) onPreview?.(item, index);
+	}
+
+	function getSortFieldLabel(field: string): string {
+		if (field === 'created_at') return 'Created';
+		if (field === 'updated_at') return 'Updated';
+		if (field === 'filename') return 'Filename';
+		if (field === 'size') return 'Size';
+		return field;
+	}
+
+	function getSortOrderLabel(order: string): string {
+		return order === 'asc' ? 'Ascending' : 'Descending';
+	}
+</script>
+
+<div class="space-y-4">
+	<!-- Breadcrumbs -->
+	<nav class="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto text-sm">
+		<Button
+			variant="ghost"
+			size="sm"
+			class="h-8 gap-1 px-2"
+			onclick={() => onNavigateFolder?.(null)}
+		>
+			<Home class="h-4 w-4" />
+			<span>Root</span>
+		</Button>
+		{#each breadcrumbs as crumb (crumb.id)}
+			<ChevronRight class="h-4 w-4 text-muted-foreground" />
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-8 px-2"
+				onclick={() => onNavigateFolder?.(crumb.id)}
+			>
+				{crumb.name}
+			</Button>
+		{/each}
+	</nav>
+
+	<!-- Controls Row -->
+	<div class="flex flex-wrap items-center justify-between gap-4">
+		<div class="flex flex-wrap items-center gap-2">
+			<Select.Root type="single" bind:value={sortField}>
+				<Select.Trigger class="w-[140px]">
+					{getSortFieldLabel(sortField)}
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="created_at">Created</Select.Item>
+					<Select.Item value="updated_at">Updated</Select.Item>
+					<Select.Item value="filename">Filename</Select.Item>
+					<Select.Item value="size">Size</Select.Item>
+				</Select.Content>
+			</Select.Root>
+
+			<Select.Root type="single" bind:value={sortOrder}>
+				<Select.Trigger class="w-[140px]">
+					{getSortOrderLabel(sortOrder)}
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="desc">Descending</Select.Item>
+					<Select.Item value="asc">Ascending</Select.Item>
+				</Select.Content>
+			</Select.Root>
+
+			{#if totalPages > 1}
+				<Pagination.Root bind:page={currentPage} count={total} perPage={limit} siblingCount={1}>
+					{#snippet children({ pages, currentPage: activePage })}
+						<Pagination.Content>
+							<Pagination.Item>
+								<Pagination.PrevButton />
+							</Pagination.Item>
+							{#each pages as pg (pg.key)}
+								{#if pg.type === 'ellipsis'}
+									<Pagination.Item>
+										<Pagination.Ellipsis />
+									</Pagination.Item>
+								{:else}
+									<Pagination.Item>
+										<Pagination.Link page={pg} isActive={activePage === pg.value}>
+											{pg.value}
+										</Pagination.Link>
+									</Pagination.Item>
+								{/if}
+							{/each}
+							<Pagination.Item>
+								<Pagination.NextButton />
+							</Pagination.Item>
+						</Pagination.Content>
+					{/snippet}
+				</Pagination.Root>
+			{/if}
+		</div>
+		<div class="flex flex-wrap items-center gap-2">
+			<ViewModeToggle
+				bind:mode={viewMode}
+				availableModes={['list', 'gallery', 'masonry', 'carousel', 'cards']}
+			/>
+			<span class="text-sm text-muted-foreground">
+				{total} file{total !== 1 ? 's' : ''} total
+			</span>
+			{#if actions}
+				{@render actions()}
+			{/if}
+		</div>
+	</div>
+
+	<!-- Content Area -->
+	{#if loading}
+		<Card.Root>
+			<Card.Content class="py-12">
+				<div class="flex flex-col items-center gap-2">
+					<Skeleton class="h-8 w-48" />
+					<Skeleton class="h-4 w-32" />
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{:else if error}
+		<Card.Root>
+			<Card.Content class="py-6">
+				<p class="text-center text-destructive">{error}</p>
+			</Card.Content>
+		</Card.Root>
+	{:else if uploads.length === 0 && folders.length === 0}
+		<Card.Root>
+			<Card.Content class="py-12">
+				<div class="space-y-2 text-center">
+					<File class="mx-auto h-12 w-12 text-muted-foreground" />
+					<h3 class="text-lg font-semibold">No files or folders</h3>
+					<p class="text-sm text-muted-foreground">This folder is empty</p>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{:else if viewMode === 'list'}
+		<FileTable
+			items={displayItems}
+			onPreview={onPreview ? handleTablePreview : undefined}
+			onDownload={onDownload ? handleTableDownload : undefined}
+			onCopyLink={onCopyLink ? handleTableCopyLink : undefined}
+			onRename={!readonly && onRename ? handleTableRename : undefined}
+			onMove={!readonly && onMove ? handleTableMove : undefined}
+			onDelete={onDeleteUpload ? handleTableDelete : undefined}
+			onFolderClick={handleFolderClick}
+			onFolderDelete={!readonly ? handleFolderDelete : undefined}
+		/>
+	{:else if viewMode === 'carousel'}
+		{#if folders.length > 0}
+			<div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+				{#each folders as folder (folder.id.toString())}
+					<FolderCard
+						{folder}
+						isPublic={isPublicFolder(folder)}
+						onclick={() => handleFolderClick(folder)}
+						onDelete={!readonly ? handleFolderDelete : undefined}
+					/>
+				{/each}
+			</div>
+		{/if}
+		<FileCarousel items={fileDisplayItems} onItemClick={handleGridItemClick} />
+	{:else if viewMode === 'cards'}
+		{#if folders.length > 0}
+			<div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+				{#each folders as folder (folder.id.toString())}
+					<FolderCard
+						{folder}
+						isPublic={isPublicFolder(folder)}
+						onclick={() => handleFolderClick(folder)}
+						onDelete={!readonly ? handleFolderDelete : undefined}
+					/>
+				{/each}
+			</div>
+		{/if}
+		<MediaCardGrid items={fileDisplayItems} onItemClick={handleGridItemClick} />
+	{:else}
+		<FileGrid
+			items={displayItems}
+			mode={viewMode === 'gallery' ? 'gallery' : 'masonry'}
+			onItemClick={handleGridItemClick}
+			onFolderClick={handleFolderClick}
+			onFolderDelete={!readonly ? handleFolderDelete : undefined}
+		/>
+	{/if}
+</div>

--- a/apps/syr/app/src/lib/components/settings-nav.svelte
+++ b/apps/syr/app/src/lib/components/settings-nav.svelte
@@ -9,7 +9,8 @@
 		Settings,
 		KeyRound,
 		Compass,
-		Shield
+		Shield,
+		Users
 	} from 'lucide-svelte';
 
 	type NavItem = { title: string; href: string; icon: typeof User };
@@ -24,7 +25,8 @@
 	];
 
 	const instanceItems: NavItem[] = [
-		{ title: 'Instance config', href: '/settings/instance-config', icon: Settings }
+		{ title: 'Instance config', href: '/settings/instance-config', icon: Settings },
+		{ title: 'Users', href: '/settings/users', icon: Users }
 	];
 
 	let { user }: { user?: { role?: string } | null } = $props();
@@ -32,7 +34,9 @@
 	let currentPath = $derived(page.url.pathname);
 	const isActive = (href: string): boolean => {
 		const norm = (s: string) => (s.endsWith('/') ? s.slice(0, -1) : s);
-		return norm(currentPath) === norm(href);
+		const normCurrent = norm(currentPath);
+		const normHref = norm(href);
+		return normCurrent === normHref || normCurrent.startsWith(normHref + '/');
 	};
 </script>
 

--- a/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
+++ b/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
@@ -1,5 +1,6 @@
 import { kvService } from '$lib/services/kv';
 import { uploadRepository } from '$lib/repositories/upload.repository';
+import { getDefaultStorageLimitBytes } from '$lib/instance-config';
 import { stringToRecordId } from '@syr-is/types';
 import type { RecordId } from 'surrealdb';
 
@@ -69,7 +70,7 @@ export class FileStoreUsageController {
 		if (override !== null && typeof override.bytes_limit === 'number' && override.bytes_limit > 0) {
 			return override.bytes_limit;
 		}
-		return MAX_STORAGE_BYTES;
+		return getDefaultStorageLimitBytes();
 	}
 
 	/**

--- a/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
+++ b/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
@@ -18,9 +18,18 @@ interface FileStoreUsageData {
 }
 
 /**
- * Maximum storage allowed per user (5GB)
+ * Maximum storage allowed per user (5GB) — instance default
  */
 export const MAX_STORAGE_BYTES = 5 * 1024 * 1024 * 1024; // 5GB
+
+/**
+ * KV type for per-user storage limit overrides
+ */
+const KV_LIMIT_TYPE = 'file_store_limit_override';
+
+interface FileStoreLimitOverride {
+	bytes_limit: number;
+}
 
 /**
  * File Store Usage Controller
@@ -39,6 +48,35 @@ export class FileStoreUsageController {
 	 */
 	private toRecordId(userId: RecordId | string): RecordId {
 		return typeof userId === 'string' ? stringToRecordId.decode(userId) : userId;
+	}
+
+	/**
+	 * Get the effective storage limit for a user.
+	 * Checks for a per-user override in KV, falls back to instance default.
+	 */
+	async getUserLimit(userId: RecordId | string): Promise<number> {
+		const index = this.getUserIndex(userId);
+		const override = await kvService.get<FileStoreLimitOverride>(KV_LIMIT_TYPE, index);
+		if (override !== null && typeof override.bytes_limit === 'number' && override.bytes_limit > 0) {
+			return override.bytes_limit;
+		}
+		return MAX_STORAGE_BYTES;
+	}
+
+	/**
+	 * Set a per-user storage limit override.
+	 */
+	async setUserLimit(userId: RecordId | string, bytesLimit: number): Promise<void> {
+		const index = this.getUserIndex(userId);
+		await kvService.set<FileStoreLimitOverride>(KV_LIMIT_TYPE, index, { bytes_limit: bytesLimit });
+	}
+
+	/**
+	 * Clear per-user storage limit override, reverting to instance default.
+	 */
+	async clearUserLimit(userId: RecordId | string): Promise<void> {
+		const index = this.getUserIndex(userId);
+		await kvService.delete(KV_LIMIT_TYPE, index);
 	}
 
 	/**
@@ -120,7 +158,7 @@ export class FileStoreUsageController {
 		bytes_remaining: number;
 	}> {
 		const bytesUsed = await this.getUsage(userId);
-		const bytesLimit = MAX_STORAGE_BYTES;
+		const bytesLimit = await this.getUserLimit(userId);
 		const percentageUsed = (bytesUsed / bytesLimit) * 100;
 		const bytesRemaining = Math.max(0, bytesLimit - bytesUsed);
 
@@ -159,13 +197,14 @@ export class FileStoreUsageController {
 		const index = this.getUserIndex(userId);
 
 		if (enforceQuota) {
+			const limit = await this.getUserLimit(userId);
 			return kvService.atomicIncrementFieldWithApplied(
 				KV_TYPE,
 				index,
 				'bytes_used',
 				bytes,
 				0,
-				MAX_STORAGE_BYTES
+				limit
 			);
 		}
 
@@ -239,8 +278,9 @@ export class FileStoreUsageController {
 		message?: string;
 	}> {
 		const currentUsage = await this.getUsage(userId);
-		const availableSpace = Math.max(0, MAX_STORAGE_BYTES - currentUsage);
-		const allowed = currentUsage + bytes <= MAX_STORAGE_BYTES;
+		const limit = await this.getUserLimit(userId);
+		const availableSpace = Math.max(0, limit - currentUsage);
+		const allowed = currentUsage + bytes <= limit;
 
 		return {
 			allowed,

--- a/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
+++ b/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
@@ -32,6 +32,15 @@ interface FileStoreLimitOverride {
 }
 
 /**
+ * KV type for per-user upload disabled flag
+ */
+const KV_UPLOAD_DISABLED_TYPE = 'file_upload_disabled';
+
+interface FileUploadDisabledFlag {
+	disabled: boolean;
+}
+
+/**
  * File Store Usage Controller
  * Manages aggregated file storage usage for users using KV storage
  */
@@ -77,6 +86,29 @@ export class FileStoreUsageController {
 	async clearUserLimit(userId: RecordId | string): Promise<void> {
 		const index = this.getUserIndex(userId);
 		await kvService.delete(KV_LIMIT_TYPE, index);
+	}
+
+	/**
+	 * Check if uploads are disabled for a user.
+	 */
+	async isUploadDisabled(userId: RecordId | string): Promise<boolean> {
+		const index = this.getUserIndex(userId);
+		const flag = await kvService.get<FileUploadDisabledFlag>(KV_UPLOAD_DISABLED_TYPE, index);
+		return flag?.disabled === true;
+	}
+
+	/**
+	 * Enable or disable uploads for a user.
+	 */
+	async setUploadDisabled(userId: RecordId | string, disabled: boolean): Promise<void> {
+		const index = this.getUserIndex(userId);
+		if (disabled) {
+			await kvService.set<FileUploadDisabledFlag>(KV_UPLOAD_DISABLED_TYPE, index, {
+				disabled: true
+			});
+		} else {
+			await kvService.delete(KV_UPLOAD_DISABLED_TYPE, index);
+		}
 	}
 
 	/**
@@ -277,6 +309,17 @@ export class FileStoreUsageController {
 		available_space: number;
 		message?: string;
 	}> {
+		if (await this.isUploadDisabled(userId)) {
+			const currentUsage = await this.getUsage(userId);
+			return {
+				allowed: false,
+				current_usage: currentUsage,
+				required_space: bytes,
+				available_space: 0,
+				message: 'Uploads are disabled for this account'
+			};
+		}
+
 		const currentUsage = await this.getUsage(userId);
 		const limit = await this.getUserLimit(userId);
 		const availableSpace = Math.max(0, limit - currentUsage);

--- a/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
+++ b/apps/syr/app/src/lib/controllers/file-store-usage.controller.ts
@@ -76,6 +76,9 @@ export class FileStoreUsageController {
 	 * Set a per-user storage limit override.
 	 */
 	async setUserLimit(userId: RecordId | string, bytesLimit: number): Promise<void> {
+		if (!Number.isInteger(bytesLimit) || bytesLimit <= 0) {
+			throw new Error('Storage limit must be a positive integer');
+		}
 		const index = this.getUserIndex(userId);
 		await kvService.set<FileStoreLimitOverride>(KV_LIMIT_TYPE, index, { bytes_limit: bytesLimit });
 	}

--- a/apps/syr/app/src/lib/instance-config.ts
+++ b/apps/syr/app/src/lib/instance-config.ts
@@ -9,6 +9,8 @@ const DEFAULT_PATH = ['me', 'profile', 'public'];
 const DEFAULT_USERNAME_COOLDOWN_DAYS = 7;
 const DEFAULT_REGISTRATION_MODE: RegistrationMode = 'open';
 const INVITE_CODE_TYPE = 'invite_code';
+const KEY_DEFAULT_STORAGE_LIMIT_GB = 'default_storage_limit_gb';
+const DEFAULT_STORAGE_LIMIT_GB = 5;
 
 /**
  * Get the profile sync asset upload path from instance config.
@@ -52,13 +54,28 @@ export async function getRegistrationMode(): Promise<RegistrationMode> {
 	return DEFAULT_REGISTRATION_MODE;
 }
 
+/**
+ * Get the instance default storage limit in bytes.
+ * Default: 5GB when unset or invalid.
+ */
+export async function getDefaultStorageLimitBytes(): Promise<number> {
+	const val = await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_DEFAULT_STORAGE_LIMIT_GB);
+	if (val != null) {
+		const n = parseFloat(String(val));
+		if (!isNaN(n) && n > 0) return Math.round(n * 1024 * 1024 * 1024);
+	}
+	return DEFAULT_STORAGE_LIMIT_GB * 1024 * 1024 * 1024;
+}
+
 export {
 	INSTANCE_CONFIG_TYPE,
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	KEY_REGISTRATION_MODE,
+	KEY_DEFAULT_STORAGE_LIMIT_GB,
 	DEFAULT_PATH,
 	DEFAULT_USERNAME_COOLDOWN_DAYS,
 	DEFAULT_REGISTRATION_MODE,
+	DEFAULT_STORAGE_LIMIT_GB,
 	INVITE_CODE_TYPE
 };

--- a/apps/syr/app/src/lib/instance-config.ts
+++ b/apps/syr/app/src/lib/instance-config.ts
@@ -11,6 +11,7 @@ const DEFAULT_REGISTRATION_MODE: RegistrationMode = 'open';
 const INVITE_CODE_TYPE = 'invite_code';
 const KEY_DEFAULT_STORAGE_LIMIT_GB = 'default_storage_limit_gb';
 const DEFAULT_STORAGE_LIMIT_GB = 5;
+const KEY_INSTANCE_STORAGE_CAPACITY_GB = 'instance_storage_capacity_gb';
 
 /**
  * Get the profile sync asset upload path from instance config.
@@ -67,12 +68,26 @@ export async function getDefaultStorageLimitBytes(): Promise<number> {
 	return DEFAULT_STORAGE_LIMIT_GB * 1024 * 1024 * 1024;
 }
 
+/**
+ * Get the instance total storage capacity in bytes.
+ * Returns 0 if not configured (admin should set this to SeaweedFS volume size).
+ */
+export async function getInstanceStorageCapacityBytes(): Promise<number> {
+	const val = await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_INSTANCE_STORAGE_CAPACITY_GB);
+	if (val != null) {
+		const n = parseFloat(String(val));
+		if (!isNaN(n) && n > 0) return Math.round(n * 1024 * 1024 * 1024);
+	}
+	return 0;
+}
+
 export {
 	INSTANCE_CONFIG_TYPE,
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	KEY_REGISTRATION_MODE,
 	KEY_DEFAULT_STORAGE_LIMIT_GB,
+	KEY_INSTANCE_STORAGE_CAPACITY_GB,
 	DEFAULT_PATH,
 	DEFAULT_USERNAME_COOLDOWN_DAYS,
 	DEFAULT_REGISTRATION_MODE,

--- a/apps/syr/app/src/lib/repositories/profile.repository.ts
+++ b/apps/syr/app/src/lib/repositories/profile.repository.ts
@@ -91,6 +91,22 @@ export class ProfileRepository extends BaseRepository<Profile> {
 	}
 
 	/**
+	 * Batch-fetch profiles for multiple user IDs in a single query.
+	 */
+	async findByUserIds(userIds: RecordId[]): Promise<Profile[]> {
+		if (userIds.length === 0) return [];
+		const result = await this.db.query<[Profile[]]>(
+			`SELECT * FROM ${this.tableName} WHERE user_id IN $userIds`,
+			{ userIds }
+		);
+		return (result[0] ?? []).map((r) => {
+			const transformed = this.transform(r);
+			const parsed = this.schema.safeParse(transformed);
+			return parsed.success ? parsed.data : (transformed as Profile);
+		});
+	}
+
+	/**
 	 * Find profile by user ID
 	 */
 	async findByUserId(userId: RecordId | string): Promise<Profile | null> {

--- a/apps/syr/app/src/lib/repositories/user.repository.ts
+++ b/apps/syr/app/src/lib/repositories/user.repository.ts
@@ -79,9 +79,16 @@ export class UserRepository extends BaseRepository<User> {
 		}
 
 		const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-		const orderField = sort?.field ?? 'created_at';
-		const orderDir = sort?.order ?? 'desc';
-		const orderClause = `ORDER BY ${orderField} ${orderDir.toUpperCase()}`;
+
+		const ALLOWED_SORT_FIELDS: Record<string, string> = {
+			created_at: 'created_at',
+			updated_at: 'updated_at',
+			username: 'username',
+			role: 'role'
+		};
+		const orderField = ALLOWED_SORT_FIELDS[sort?.field ?? 'created_at'] ?? 'created_at';
+		const orderDir = sort?.order === 'asc' ? 'ASC' : 'DESC';
+		const orderClause = `ORDER BY ${orderField} ${orderDir}`;
 
 		const [dataResult, countResult] = await Promise.all([
 			this.db.query<[User[]]>(

--- a/apps/syr/app/src/lib/repositories/user.repository.ts
+++ b/apps/syr/app/src/lib/repositories/user.repository.ts
@@ -61,6 +61,45 @@ export class UserRepository extends BaseRepository<User> {
 	}
 
 	/**
+	 * Find users with optional username/DID search, pagination, and sorting.
+	 */
+	async findManyWithSearch(options: {
+		limit?: number;
+		offset?: number;
+		search?: string;
+		sort?: { field: string; order: 'asc' | 'desc' };
+	}): Promise<{ data: User[]; total: number }> {
+		const { limit = 20, offset = 0, search, sort } = options;
+		const params: Record<string, unknown> = { limit, offset };
+		const conditions: string[] = [];
+
+		if (search && search.trim()) {
+			conditions.push('(username CONTAINS $search OR did CONTAINS $search)');
+			params.search = search.trim();
+		}
+
+		const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+		const orderField = sort?.field ?? 'created_at';
+		const orderDir = sort?.order ?? 'desc';
+		const orderClause = `ORDER BY ${orderField} ${orderDir.toUpperCase()}`;
+
+		const [dataResult, countResult] = await Promise.all([
+			this.db.query<[User[]]>(
+				`SELECT * FROM ${this.tableName} ${whereClause} ${orderClause} LIMIT $limit START $offset`,
+				params
+			),
+			this.db.query<[{ count: number }[]]>(
+				`SELECT count() AS count FROM ${this.tableName} ${whereClause} GROUP ALL`,
+				params
+			)
+		]);
+
+		const data = (dataResult[0] ?? []).map((r) => this.validate(r));
+		const total = countResult[0]?.[0]?.count ?? 0;
+		return { data, total };
+	}
+
+	/**
 	 * Update username and set username_last_updated to now.
 	 * Caller must validate cooldown and uniqueness.
 	 */

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
@@ -7,6 +7,8 @@ import {
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	DEFAULT_PATH,
 	DEFAULT_USERNAME_COOLDOWN_DAYS,
+	KEY_DEFAULT_STORAGE_LIMIT_GB,
+	DEFAULT_STORAGE_LIMIT_GB,
 	INVITE_CODE_TYPE
 } from '$lib/instance-config';
 import { getRegistrationMode } from '$lib/instance-config';
@@ -27,6 +29,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 		String(DEFAULT_USERNAME_COOLDOWN_DAYS);
 
 	const registrationMode = await getRegistrationMode();
+
+	const defaultStorageLimitGb =
+		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_DEFAULT_STORAGE_LIMIT_GB)) ??
+		String(DEFAULT_STORAGE_LIMIT_GB);
 
 	const inviteCodeEntries = await kvService.getByType(INVITE_CODE_TYPE);
 	const inviteCodes: {
@@ -61,6 +67,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 		profileSyncAssetPath,
 		usernameCooldownDays,
 		registrationMode,
+		defaultStorageLimitGb,
 		inviteCodes,
 		instanceDiscoveryRegistries: instanceDiscoveryRows.map((r) => ({
 			id: r.id.toString(),

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
@@ -31,12 +31,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	const registrationMode = await getRegistrationMode();
 
-	const defaultStorageLimitGb =
-		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_DEFAULT_STORAGE_LIMIT_GB)) ??
-		String(DEFAULT_STORAGE_LIMIT_GB);
-
-	const instanceStorageCapacityGb =
-		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_INSTANCE_STORAGE_CAPACITY_GB)) ?? '';
+	const [rawStorageLimit, rawStorageCapacity] = await Promise.all([
+		kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_DEFAULT_STORAGE_LIMIT_GB),
+		kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_INSTANCE_STORAGE_CAPACITY_GB)
+	]);
+	const defaultStorageLimitGb = rawStorageLimit ?? String(DEFAULT_STORAGE_LIMIT_GB);
+	const instanceStorageCapacityGb = rawStorageCapacity ?? '';
 
 	const inviteCodeEntries = await kvService.getByType(INVITE_CODE_TYPE);
 	const inviteCodes: {

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.server.ts
@@ -9,6 +9,7 @@ import {
 	DEFAULT_USERNAME_COOLDOWN_DAYS,
 	KEY_DEFAULT_STORAGE_LIMIT_GB,
 	DEFAULT_STORAGE_LIMIT_GB,
+	KEY_INSTANCE_STORAGE_CAPACITY_GB,
 	INVITE_CODE_TYPE
 } from '$lib/instance-config';
 import { getRegistrationMode } from '$lib/instance-config';
@@ -33,6 +34,9 @@ export const load: PageServerLoad = async ({ parent }) => {
 	const defaultStorageLimitGb =
 		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_DEFAULT_STORAGE_LIMIT_GB)) ??
 		String(DEFAULT_STORAGE_LIMIT_GB);
+
+	const instanceStorageCapacityGb =
+		(await kvService.get<string>(INSTANCE_CONFIG_TYPE, KEY_INSTANCE_STORAGE_CAPACITY_GB)) ?? '';
 
 	const inviteCodeEntries = await kvService.getByType(INVITE_CODE_TYPE);
 	const inviteCodes: {
@@ -68,6 +72,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 		usernameCooldownDays,
 		registrationMode,
 		defaultStorageLimitGb,
+		instanceStorageCapacityGb,
 		inviteCodes,
 		instanceDiscoveryRegistries: instanceDiscoveryRows.map((r) => ({
 			id: r.id.toString(),

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
@@ -63,9 +63,19 @@
 		overviewLoading = true;
 		try {
 			const res = await fetch('/api/admin/storage');
+			if (!res.ok) {
+				console.error('[instance-config] Storage overview fetch failed:', res.status);
+				storageOverview = null;
+				return;
+			}
 			const json = await res.json();
-			if (json.status === 'success') storageOverview = json.data;
-		} catch {
+			if (json.status === 'success') {
+				storageOverview = json.data;
+			} else {
+				storageOverview = null;
+			}
+		} catch (err) {
+			console.error('[instance-config] Storage overview error:', err);
 			storageOverview = null;
 		} finally {
 			overviewLoading = false;
@@ -173,7 +183,7 @@
 			}
 			toast.success('Instance storage capacity updated');
 			await invalidateAll();
-			loadStorageOverview();
+			await loadStorageOverview();
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to update');
 		} finally {

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
@@ -8,7 +8,9 @@
 	import type { PageData } from './$types';
 	import RemoveDiscoveryRegistryDialog from '$lib/components/fragments/remove-discovery-registry-dialog.svelte';
 	import DeleteInviteCodeDialog from '$lib/components/fragments/delete-invite-code-dialog.svelte';
-	import { Copy } from 'lucide-svelte';
+	import { Copy, AlertTriangle } from 'lucide-svelte';
+	import * as Table from '@syr-is/ui/table';
+	import { Progress } from '@syr-is/ui/progress';
 
 	let { data }: { data: PageData } = $props();
 
@@ -23,6 +25,20 @@
 
 	let defaultStorageLimitGb = $state('');
 	let storageLimitLoading = $state(false);
+	let instanceStorageCapacityGb = $state('');
+	let capacityLoading = $state(false);
+
+	// Storage overview state
+	type StorageOverview = {
+		capacity: number;
+		total_used: number;
+		total_allocated: number;
+		default_limit: number;
+		user_count: number;
+		users: Array<{ id: string; username: string; bytes_used: number; bytes_limit: number }>;
+	};
+	let storageOverview = $state<StorageOverview | null>(null);
+	let overviewLoading = $state(false);
 
 	let newCodeMaxUses = $state<number | null>(null);
 	let creatingCode = $state(false);
@@ -40,6 +56,25 @@
 		registrationModeDraft = data.registrationMode;
 		registrationModePersisted = data.registrationMode;
 		defaultStorageLimitGb = data.defaultStorageLimitGb;
+		instanceStorageCapacityGb = data.instanceStorageCapacityGb;
+	});
+
+	async function loadStorageOverview() {
+		overviewLoading = true;
+		try {
+			const res = await fetch('/api/admin/storage');
+			const json = await res.json();
+			if (json.status === 'success') storageOverview = json.data;
+		} catch {
+			storageOverview = null;
+		} finally {
+			overviewLoading = false;
+		}
+	}
+
+	// Load overview on mount
+	$effect(() => {
+		loadStorageOverview();
 	});
 
 	async function saveProfileSyncPath() {
@@ -116,6 +151,42 @@
 		} finally {
 			storageLimitLoading = false;
 		}
+	}
+
+	async function saveInstanceCapacity() {
+		const n = parseFloat(instanceStorageCapacityGb);
+		if (isNaN(n) || n <= 0) {
+			toast.error('Enter a positive number');
+			return;
+		}
+		capacityLoading = true;
+		try {
+			const res = await fetch('/api/instance-config/instance_storage_capacity_gb', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: String(n) })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to update');
+				return;
+			}
+			toast.success('Instance storage capacity updated');
+			await invalidateAll();
+			loadStorageOverview();
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to update');
+		} finally {
+			capacityLoading = false;
+		}
+	}
+
+	function fmtBytes(bytes: number): string {
+		if (bytes === 0) return '0 B';
+		const k = 1024;
+		const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+		const i = Math.floor(Math.log(bytes) / Math.log(k));
+		return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 	}
 
 	async function addInstanceRegistry() {
@@ -367,6 +438,32 @@
 
 	<Card.Root>
 		<Card.Header>
+			<Card.Title>Instance storage capacity (GB)</Card.Title>
+			<Card.Description>
+				Total storage available on your SeaweedFS volume. Set this to your actual disk/volume
+				capacity so the overview below can warn about over-allocation.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="flex gap-2">
+				<Input
+					id="instance-storage-capacity-gb"
+					aria-label="Instance storage capacity in GB"
+					bind:value={instanceStorageCapacityGb}
+					type="number"
+					min={1}
+					step={1}
+					placeholder="Not configured"
+				/>
+				<Button onclick={saveInstanceCapacity} disabled={capacityLoading}>
+					{capacityLoading ? 'Saving…' : 'Save'}
+				</Button>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header>
 			<Card.Title>Default storage limit (GB)</Card.Title>
 			<Card.Description>
 				Default file storage limit per user. Users without a custom override will use this limit.
@@ -387,6 +484,108 @@
 					{storageLimitLoading ? 'Saving…' : 'Save'}
 				</Button>
 			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Storage overview</Card.Title>
+			<Card.Description>
+				Instance-wide storage usage and allocation across all users.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			{#if overviewLoading}
+				<p class="text-sm text-muted-foreground">Loading…</p>
+			{:else if storageOverview}
+				{@const o = storageOverview}
+				{#if o.capacity > 0}
+					{@const usedPct = Math.min(100, (o.total_used / o.capacity) * 100)}
+					{@const allocPct = Math.min(100, (o.total_allocated / o.capacity) * 100)}
+					<div class="space-y-2">
+						<div class="flex justify-between text-sm">
+							<span>{fmtBytes(o.total_used)} used</span>
+							<span>{fmtBytes(o.total_allocated)} allocated</span>
+							<span>{fmtBytes(o.capacity)} capacity</span>
+						</div>
+						<!-- Stacked bar -->
+						<div class="relative h-4 w-full overflow-hidden rounded-full bg-muted">
+							{#if allocPct > 0}
+								<div
+									class="absolute inset-y-0 left-0 rounded-full bg-primary/25"
+									style="width: {allocPct}%"
+								></div>
+							{/if}
+							{#if usedPct > 0}
+								<div
+									class="absolute inset-y-0 left-0 rounded-full bg-primary"
+									style="width: {usedPct}%"
+								></div>
+							{/if}
+						</div>
+						<div class="flex items-center gap-4 text-xs text-muted-foreground">
+							<span class="flex items-center gap-1">
+								<span class="inline-block h-2.5 w-2.5 rounded-full bg-primary"></span>
+								Used
+							</span>
+							<span class="flex items-center gap-1">
+								<span class="inline-block h-2.5 w-2.5 rounded-full bg-primary/25"></span>
+								Allocated
+							</span>
+							<span class="flex items-center gap-1">
+								<span class="inline-block h-2.5 w-2.5 rounded-full border bg-muted"></span>
+								Free
+							</span>
+						</div>
+						{#if o.total_allocated > o.capacity}
+							<div
+								class="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+							>
+								<AlertTriangle class="h-4 w-4 shrink-0" />
+								Over-allocated by {fmtBytes(o.total_allocated - o.capacity)}
+							</div>
+						{/if}
+					</div>
+				{:else}
+					<p class="text-sm text-muted-foreground">
+						Set the instance storage capacity above to see the allocation overview.
+					</p>
+					<div class="flex justify-between text-sm">
+						<span><strong>Used:</strong> {fmtBytes(o.total_used)}</span>
+						<span><strong>Allocated:</strong> {fmtBytes(o.total_allocated)}</span>
+						<span><strong>Users:</strong> {o.user_count}</span>
+					</div>
+				{/if}
+
+				{#if o.users.length > 0}
+					<Table.Root>
+						<Table.Header>
+							<Table.Row>
+								<Table.Head>User</Table.Head>
+								<Table.Head>Used</Table.Head>
+								<Table.Head>Limit</Table.Head>
+								<Table.Head>Usage</Table.Head>
+							</Table.Row>
+						</Table.Header>
+						<Table.Body>
+							{#each o.users as u (u.id)}
+								{@const pct =
+									u.bytes_limit > 0 ? Math.min(100, (u.bytes_used / u.bytes_limit) * 100) : 0}
+								<Table.Row>
+									<Table.Cell class="text-sm font-medium">{u.username}</Table.Cell>
+									<Table.Cell class="text-xs">{fmtBytes(u.bytes_used)}</Table.Cell>
+									<Table.Cell class="text-xs">{fmtBytes(u.bytes_limit)}</Table.Cell>
+									<Table.Cell class="w-32">
+										<Progress value={pct} />
+									</Table.Cell>
+								</Table.Row>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				{/if}
+			{:else}
+				<p class="text-sm text-muted-foreground">Failed to load storage overview.</p>
+			{/if}
 		</Card.Content>
 	</Card.Root>
 

--- a/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/instance-config/+page.svelte
@@ -21,6 +21,9 @@
 	let registrationModePersisted = $state('open');
 	let registrationModeLoading = $state(false);
 
+	let defaultStorageLimitGb = $state('');
+	let storageLimitLoading = $state(false);
+
 	let newCodeMaxUses = $state<number | null>(null);
 	let creatingCode = $state(false);
 	let deleteCodeDialogOpen = $state(false);
@@ -36,6 +39,7 @@
 		usernameCooldownDays = data.usernameCooldownDays;
 		registrationModeDraft = data.registrationMode;
 		registrationModePersisted = data.registrationMode;
+		defaultStorageLimitGb = data.defaultStorageLimitGb;
 	});
 
 	async function saveProfileSyncPath() {
@@ -84,6 +88,33 @@
 			toast.error(e instanceof Error ? e.message : 'Failed to update');
 		} finally {
 			cooldownLoading = false;
+		}
+	}
+
+	async function saveDefaultStorageLimit() {
+		const n = parseFloat(defaultStorageLimitGb);
+		if (isNaN(n) || n <= 0) {
+			toast.error('Enter a positive number');
+			return;
+		}
+		storageLimitLoading = true;
+		try {
+			const res = await fetch('/api/instance-config/default_storage_limit_gb', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: String(n) })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to update');
+				return;
+			}
+			toast.success('Default storage limit updated');
+			await invalidateAll();
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to update');
+		} finally {
+			storageLimitLoading = false;
 		}
 	}
 
@@ -329,6 +360,31 @@
 				/>
 				<Button onclick={saveUsernameCooldown} disabled={cooldownLoading}>
 					{cooldownLoading ? 'Saving…' : 'Save'}
+				</Button>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Default storage limit (GB)</Card.Title>
+			<Card.Description>
+				Default file storage limit per user. Users without a custom override will use this limit.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="flex gap-2">
+				<Input
+					id="default-storage-limit-gb"
+					aria-label="Default storage limit in GB"
+					bind:value={defaultStorageLimitGb}
+					type="number"
+					min={0.1}
+					step={0.1}
+					placeholder="5"
+				/>
+				<Button onclick={saveDefaultStorageLimit} disabled={storageLimitLoading}>
+					{storageLimitLoading ? 'Saving…' : 'Save'}
 				</Button>
 			</div>
 		</Card.Content>

--- a/apps/syr/app/src/routes/(private)/settings/users/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/users/+page.server.ts
@@ -1,0 +1,26 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { z } from 'zod';
+
+const QuerySchema = z.object({
+	page: z.coerce.number().int().min(1).default(1),
+	size: z.coerce.number().int().default(20),
+	search: z.string().default('')
+});
+
+export const load: PageServerLoad = async ({ parent, url }) => {
+	const { user } = await parent();
+	if (user?.role !== 'ADMIN') {
+		throw redirect(303, '/settings/profile');
+	}
+
+	const parsed = QuerySchema.safeParse({
+		page: url.searchParams.get('page') ?? undefined,
+		size: url.searchParams.get('size') ?? undefined,
+		search: url.searchParams.get('search') ?? undefined
+	});
+
+	const { page, size, search } = parsed.success ? parsed.data : { page: 1, size: 20, search: '' };
+
+	return { page, size, search, sizes: [10, 20, 50] };
+};

--- a/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+	import { page as pageStore } from '$app/state';
+	import { goto } from '$app/navigation';
+	import * as Table from '@syr-is/ui/table';
+	import * as Pagination from '@syr-is/ui/pagination';
+	import { Input } from '@syr-is/ui/input';
+	import { buttonVariants } from '@syr-is/ui/button';
+	import { cn } from '$lib/utils';
+	import {
+		DropdownMenu,
+		DropdownMenuContent,
+		DropdownMenuTrigger,
+		DropdownMenuRadioGroup,
+		DropdownMenuRadioItem
+	} from '@syr-is/ui/dropdown-menu';
+	import { resolve } from '$app/paths';
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+
+	type UserRow = {
+		id: string;
+		username: string;
+		did: string | null;
+		role: string;
+		created_at: string;
+		display_name: string;
+		avatar_url: string | null;
+	};
+
+	const sizes = $derived(data.sizes ?? [10, 20, 50]);
+	let page = $state(1);
+	let size = $state(20);
+	let pageSizeValue = $state('20');
+	let searchQuery = $state('');
+	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	$effect(() => {
+		page = data.page ?? 1;
+		size = data.size ?? 20;
+		pageSizeValue = String(data.size ?? 20);
+		searchQuery = data.search ?? '';
+	});
+
+	let rows = $state<UserRow[]>([]);
+	let total = $state(0);
+	let loading = $state(false);
+
+	$effect(() => {
+		const n = parseInt(pageSizeValue, 10);
+		if (sizes.includes(n) && n !== size) size = n;
+	});
+
+	async function loadUsers(currentPage: number, currentSize: number, search: string) {
+		loading = true;
+		try {
+			let qs = `page=${currentPage}&size=${currentSize}`;
+			if (search.trim()) qs += `&search=${encodeURIComponent(search.trim())}`;
+
+			const res = await fetch(`/api/admin/users?${qs}`);
+			const json = await res.json();
+			if (json.status === 'success') {
+				rows = json.data;
+				total = json.pagination?.total ?? rows.length;
+			} else {
+				rows = [];
+				total = 0;
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function updateUrl(currentPage: number, currentSize: number, search: string) {
+		const url = new URL(pageStore.url);
+		const curPage = Number(url.searchParams.get('page') ?? '1');
+		const curSize = Number(url.searchParams.get('size') ?? '20');
+		const curSearch = url.searchParams.get('search') ?? '';
+		if (curPage === currentPage && curSize === currentSize && curSearch === search) return;
+		url.searchParams.set('page', String(currentPage));
+		url.searchParams.set('size', String(currentSize));
+		if (search.trim()) {
+			url.searchParams.set('search', search.trim());
+		} else {
+			url.searchParams.delete('search');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	$effect(() => {
+		updateUrl(page, size, searchQuery);
+		loadUsers(page, size, searchQuery);
+	});
+
+	function handleSearchInput(e: Event) {
+		const value = (e.target as HTMLInputElement).value;
+		if (searchTimeout) clearTimeout(searchTimeout);
+		searchTimeout = setTimeout(() => {
+			searchQuery = value;
+			page = 1;
+		}, 300);
+	}
+
+	function truncateDid(did: string | null): string {
+		if (!did) return '—';
+		if (did.length <= 24) return did;
+		return did.slice(0, 16) + '…' + did.slice(-6);
+	}
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+
+	const totalPages = $derived(Math.max(1, Math.ceil(total / size)));
+</script>
+
+<svelte:head>
+	<title>Users | Settings | SYR</title>
+</svelte:head>
+
+<div class="mx-auto max-w-4xl space-y-4">
+	<div class="flex items-center justify-between gap-4">
+		<h2 class="text-lg font-semibold">Users</h2>
+		<Input
+			type="search"
+			placeholder="Search by username or DID…"
+			class="max-w-xs"
+			value={searchQuery}
+			oninput={handleSearchInput}
+		/>
+	</div>
+
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Username</Table.Head>
+				<Table.Head>DID</Table.Head>
+				<Table.Head>Role</Table.Head>
+				<Table.Head>Created</Table.Head>
+				<Table.Head class="text-right">Actions</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={5} class="py-8 text-center text-muted-foreground">
+						Loading…
+					</Table.Cell>
+				</Table.Row>
+			{:else if rows.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={5} class="py-8 text-center text-muted-foreground">
+						No users found.
+					</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each rows as user (user.id)}
+					<Table.Row>
+						<Table.Cell class="font-medium">
+							{user.display_name}
+							<span class="ml-1 text-xs text-muted-foreground">@{user.username}</span>
+						</Table.Cell>
+						<Table.Cell>
+							<code class="text-xs">{truncateDid(user.did)}</code>
+						</Table.Cell>
+						<Table.Cell>
+							<span
+								class={cn(
+									'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+									user.role === 'ADMIN'
+										? 'bg-primary/10 text-primary'
+										: 'bg-muted text-muted-foreground'
+								)}
+							>
+								{user.role}
+							</span>
+						</Table.Cell>
+						<Table.Cell class="text-sm text-muted-foreground">
+							{formatDate(user.created_at)}
+						</Table.Cell>
+						<Table.Cell class="text-right">
+							<a
+								href={resolve(`/settings/users/${encodeURIComponent(user.id)}`)}
+								class={buttonVariants({ variant: 'outline', size: 'sm' })}
+							>
+								Manage
+							</a>
+						</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+
+	<div class="flex items-center justify-between">
+		<DropdownMenu>
+			<DropdownMenuTrigger class={buttonVariants({ variant: 'outline', size: 'sm' })}>
+				{size} per page
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				<DropdownMenuRadioGroup bind:value={pageSizeValue}>
+					{#each sizes as s (s)}
+						<DropdownMenuRadioItem value={String(s)}>{s}</DropdownMenuRadioItem>
+					{/each}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+
+		{#if totalPages > 1}
+			<Pagination.Root count={total} perPage={size} bind:page>
+				{#snippet children({ pages, currentPage })}
+					<Pagination.Content>
+						{#if currentPage > 1}
+							<Pagination.Item>
+								<Pagination.PrevButton />
+							</Pagination.Item>
+						{/if}
+						{#each pages as p (p.key)}
+							{#if p.type === 'ellipsis'}
+								<Pagination.Item>
+									<Pagination.Ellipsis />
+								</Pagination.Item>
+							{:else}
+								<Pagination.Item>
+									<Pagination.Link page={p} isActive={currentPage === p.value}>
+										{p.value}
+									</Pagination.Link>
+								</Pagination.Item>
+							{/if}
+						{/each}
+						{#if currentPage < totalPages}
+							<Pagination.Item>
+								<Pagination.NextButton />
+							</Pagination.Item>
+						{/if}
+					</Pagination.Content>
+				{/snippet}
+			</Pagination.Root>
+		{/if}
+	</div>
+</div>

--- a/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
@@ -46,6 +46,7 @@
 	let rows = $state<UserRow[]>([]);
 	let total = $state(0);
 	let loading = $state(false);
+	let fetchError = $state<string | null>(null);
 
 	$effect(() => {
 		const n = parseInt(pageSizeValue, 10);
@@ -58,11 +59,18 @@
 		const signal = abortController.signal;
 
 		loading = true;
+		fetchError = null;
 		try {
 			let qs = `page=${currentPage}&size=${currentSize}`;
 			if (search.trim()) qs += `&search=${encodeURIComponent(search.trim())}`;
 
 			const res = await fetch(`/api/admin/users?${qs}`, { signal });
+			if (!res.ok) {
+				rows = [];
+				total = 0;
+				fetchError = `Failed to load users (${res.status})`;
+				return;
+			}
 			const json = await res.json();
 			if (json.status === 'success') {
 				rows = json.data;
@@ -70,11 +78,13 @@
 			} else {
 				rows = [];
 				total = 0;
+				fetchError = 'Unexpected response';
 			}
 		} catch (e) {
 			if (e instanceof DOMException && e.name === 'AbortError') return;
 			rows = [];
 			total = 0;
+			fetchError = e instanceof Error ? e.message : 'Failed to load users';
 		} finally {
 			if (!signal.aborted) loading = false;
 		}
@@ -164,6 +174,12 @@
 				<Table.Row>
 					<Table.Cell colspan={5} class="py-8 text-center text-muted-foreground">
 						Loading…
+					</Table.Cell>
+				</Table.Row>
+			{:else if fetchError}
+				<Table.Row>
+					<Table.Cell colspan={5} class="py-8 text-center text-destructive">
+						{fetchError}
 					</Table.Cell>
 				</Table.Row>
 			{:else if rows.length === 0}

--- a/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
@@ -29,10 +29,10 @@
 	};
 
 	const sizes = $derived(data.sizes ?? [10, 20, 50]);
-	let page = $state(1);
-	let size = $state(20);
-	let pageSizeValue = $state('20');
-	let searchQuery = $state('');
+	let page = $state(data.page ?? 1);
+	let size = $state(data.size ?? 20);
+	let pageSizeValue = $state(String(data.size ?? 20));
+	let searchQuery = $state(data.search ?? '');
 	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 	let abortController: AbortController | null = null;
 
@@ -64,7 +64,7 @@
 			let qs = `page=${currentPage}&size=${currentSize}`;
 			if (search.trim()) qs += `&search=${encodeURIComponent(search.trim())}`;
 
-			const res = await fetch(`/api/admin/users?${qs}`, { signal });
+			const res = await fetch(`${resolve('/api/admin/users')}?${qs}`, { signal });
 			if (!res.ok) {
 				rows = [];
 				total = 0;
@@ -153,6 +153,7 @@
 		<Input
 			type="search"
 			placeholder="Search by username or DID…"
+			aria-label="Search users"
 			class="max-w-xs"
 			value={searchQuery}
 			oninput={handleSearchInput}

--- a/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/+page.svelte
@@ -34,6 +34,7 @@
 	let pageSizeValue = $state('20');
 	let searchQuery = $state('');
 	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+	let abortController: AbortController | null = null;
 
 	$effect(() => {
 		page = data.page ?? 1;
@@ -52,12 +53,16 @@
 	});
 
 	async function loadUsers(currentPage: number, currentSize: number, search: string) {
+		abortController?.abort();
+		abortController = new AbortController();
+		const signal = abortController.signal;
+
 		loading = true;
 		try {
 			let qs = `page=${currentPage}&size=${currentSize}`;
 			if (search.trim()) qs += `&search=${encodeURIComponent(search.trim())}`;
 
-			const res = await fetch(`/api/admin/users?${qs}`);
+			const res = await fetch(`/api/admin/users?${qs}`, { signal });
 			const json = await res.json();
 			if (json.status === 'success') {
 				rows = json.data;
@@ -66,8 +71,12 @@
 				rows = [];
 				total = 0;
 			}
+		} catch (e) {
+			if (e instanceof DOMException && e.name === 'AbortError') return;
+			rows = [];
+			total = 0;
 		} finally {
-			loading = false;
+			if (!signal.aborted) loading = false;
 		}
 	}
 
@@ -91,6 +100,11 @@
 	$effect(() => {
 		updateUrl(page, size, searchQuery);
 		loadUsers(page, size, searchQuery);
+
+		return () => {
+			if (searchTimeout) clearTimeout(searchTimeout);
+			abortController?.abort();
+		};
 	});
 
 	function handleSearchInput(e: Event) {

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.server.ts
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.server.ts
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent, params }) => {
+	const { user } = await parent();
+	if (user?.role !== 'ADMIN') {
+		throw redirect(303, '/settings/profile');
+	}
+
+	return { userId: params.userId };
+};

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -7,7 +7,7 @@
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { List, FolderOpen, ExternalLink } from 'lucide-svelte';
+	import { List, FolderOpen, ExternalLink, AlertTriangle } from 'lucide-svelte';
 	import FileBrowser from '$lib/components/fragments/file-browser.svelte';
 	import AdminDeleteUserDialog from '$lib/components/fragments/admin-delete-user-dialog.svelte';
 	import AdminDeletePostDialog from '$lib/components/fragments/admin-delete-post-dialog.svelte';
@@ -64,6 +64,24 @@
 	let limitSaving = $state(false);
 	let toggleSaving = $state(false);
 
+	// Instance storage overview for context
+	type InstanceOverview = {
+		capacity: number;
+		total_used: number;
+		total_allocated: number;
+	};
+	let instanceOverview = $state<InstanceOverview | null>(null);
+
+	async function loadInstanceOverview() {
+		try {
+			const res = await fetch('/api/admin/storage');
+			const json = await res.json();
+			if (json.status === 'success') instanceOverview = json.data;
+		} catch {
+			instanceOverview = null;
+		}
+	}
+
 	async function loadStorage() {
 		storageLoading = true;
 		try {
@@ -103,6 +121,7 @@
 			storage = json.data;
 			customLimitGb = '';
 			toast.success('Storage limit updated');
+			loadInstanceOverview();
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to set limit');
 		} finally {
@@ -125,6 +144,7 @@
 			}
 			storage = json.data;
 			toast.success('Storage limit reset to default');
+			loadInstanceOverview();
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Failed to reset');
 		} finally {
@@ -371,6 +391,7 @@
 
 			loadUser();
 			loadStorage();
+			loadInstanceOverview();
 			loadPosts();
 			loadUploads();
 		}
@@ -456,6 +477,47 @@
 						{formatBytes(storage.bytes_remaining)} remaining
 					</p>
 				</div>
+				{#if instanceOverview && instanceOverview.capacity > 0}
+					{@const cap = instanceOverview.capacity}
+					{@const thisUserPct = Math.min(100, (storage.bytes_limit / cap) * 100)}
+					{@const otherAllocated = instanceOverview.total_allocated - storage.bytes_limit}
+					{@const otherPct = Math.min(100, (otherAllocated / cap) * 100)}
+					{@const totalAllocPct = Math.min(
+						100,
+						((otherAllocated + storage.bytes_limit) / cap) * 100
+					)}
+					<div class="space-y-1 border-t pt-3">
+						<p class="text-xs font-medium text-muted-foreground">Instance capacity</p>
+						<div class="relative h-3 w-full overflow-hidden rounded-full bg-muted">
+							<div
+								class="absolute inset-y-0 left-0 rounded-full bg-muted-foreground/20"
+								style="width: {Math.min(100, otherPct + thisUserPct)}%"
+							></div>
+							<div
+								class="absolute inset-y-0 rounded-full bg-primary"
+								style="left: {otherPct}%; width: {thisUserPct}%"
+							></div>
+						</div>
+						<div class="flex items-center gap-3 text-xs text-muted-foreground">
+							<span class="flex items-center gap-1">
+								<span class="inline-block h-2 w-2 rounded-full bg-primary"></span>
+								This user: {formatBytes(storage.bytes_limit)}
+							</span>
+							<span class="flex items-center gap-1">
+								<span class="inline-block h-2 w-2 rounded-full bg-muted-foreground/20"></span>
+								Others: {formatBytes(otherAllocated)}
+							</span>
+							<span>Total: {formatBytes(cap)}</span>
+						</div>
+						{#if totalAllocPct > 100}
+							<div class="flex items-center gap-1 text-xs text-destructive">
+								<AlertTriangle class="h-3 w-3" />
+								Over-allocated
+							</div>
+						{/if}
+					</div>
+				{/if}
+
 				<div class="flex flex-wrap gap-2">
 					<Input
 						type="number"

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -37,7 +37,14 @@
 		try {
 			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}`);
 			const json = await res.json();
-			if (json.status === 'success') userInfo = json.data;
+			if (json.status === 'success') {
+				userInfo = json.data;
+			} else {
+				userInfo = null;
+			}
+		} catch (e) {
+			console.error('[admin] Failed to load user:', e);
+			userInfo = null;
 		} finally {
 			_userLoading = false;
 		}
@@ -62,7 +69,14 @@
 		try {
 			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/storage`);
 			const json = await res.json();
-			if (json.status === 'success') storage = json.data;
+			if (json.status === 'success') {
+				storage = json.data;
+			} else {
+				storage = null;
+			}
+		} catch (e) {
+			console.error('[admin] Failed to load storage:', e);
+			storage = null;
 		} finally {
 			storageLoading = false;
 		}
@@ -262,14 +276,16 @@
 	function navigateFolder(folderId: string | null) {
 		browserFolderId = folderId;
 		browserPage = 1;
-		loadBrowserFolders();
-		loadBrowserUploads();
 	}
 
 	function handleBrowserDelete(upload: UploadWithCompositeId) {
+		if (!upload.did || !upload.local_id) {
+			toast.error('Cannot delete: missing file identifiers');
+			return;
+		}
 		deleteUploadTarget = {
-			did: upload.did ?? '',
-			localId: upload.local_id ?? '',
+			did: upload.did,
+			localId: upload.local_id,
 			filename: upload.filename
 		};
 		deleteUploadOpen = true;
@@ -280,8 +296,7 @@
 		if (mode === 'browser') {
 			browserFolderId = null;
 			browserPage = 1;
-			loadBrowserFolders();
-			loadBrowserUploads();
+			// $effect watching these will trigger the loads
 		}
 	}
 
@@ -323,14 +338,22 @@
 	});
 
 	function openDeletePost(post: PostRow) {
-		deletePostTarget = { did: post.did ?? '', localId: post.local_id ?? '', title: post.title };
+		if (!post.did || !post.local_id) {
+			toast.error('Cannot delete: missing post identifiers');
+			return;
+		}
+		deletePostTarget = { did: post.did, localId: post.local_id, title: post.title };
 		deletePostOpen = true;
 	}
 
 	function openDeleteUpload(upload: UploadRow) {
+		if (!upload.did || !upload.local_id) {
+			toast.error('Cannot delete: missing file identifiers');
+			return;
+		}
 		deleteUploadTarget = {
-			did: upload.did ?? '',
-			localId: upload.local_id ?? '',
+			did: upload.did,
+			localId: upload.local_id,
 			filename: upload.filename
 		};
 		deleteUploadOpen = true;
@@ -339,17 +362,18 @@
 	// --- Init ---
 	$effect(() => {
 		if (userId) {
+			// Reset all pagination and state when switching users
+			postsPage = 1;
+			uploadsPage = 1;
+			browserFolderId = null;
+			browserPage = 1;
+			uploadViewMode = 'list';
+
 			loadUser();
 			loadStorage();
+			loadPosts();
+			loadUploads();
 		}
-	});
-
-	$effect(() => {
-		if (userId) loadPosts();
-	});
-
-	$effect(() => {
-		if (userId) loadUploads();
 	});
 
 	function formatBytes(bytes: number): string {

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -31,22 +31,28 @@
 	};
 	let userInfo = $state<UserInfo | null>(null);
 	let _userLoading = $state(true);
+	let requestId = $state(0);
 
 	async function loadUser() {
+		const myId = ++requestId;
 		_userLoading = true;
+		userInfo = null;
 		try {
 			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}`);
-			const json = await res.json();
-			if (json.status === 'success') {
-				userInfo = json.data;
-			} else {
+			if (myId !== requestId) return;
+			if (!res.ok) {
 				userInfo = null;
+				return;
 			}
+			const json = await res.json();
+			if (myId !== requestId) return;
+			userInfo = json.status === 'success' ? json.data : null;
 		} catch (e) {
+			if (myId !== requestId) return;
 			console.error('[admin] Failed to load user:', e);
 			userInfo = null;
 		} finally {
-			_userLoading = false;
+			if (myId === requestId) _userLoading = false;
 		}
 	}
 
@@ -197,11 +203,28 @@
 			const res = await fetch(
 				`/api/admin/users/${encodeURIComponent(userId)}/posts?page=${postsPage}&size=10`
 			);
+			if (!res.ok) {
+				posts = [];
+				postsTotal = 0;
+				return;
+			}
 			const json = await res.json();
 			if (json.status === 'success') {
 				posts = json.data;
 				postsTotal = json.pagination?.total ?? 0;
+				// Clamp page if total shrank
+				const lastPage = Math.max(1, Math.ceil(postsTotal / 10));
+				if (postsPage > lastPage) {
+					postsPage = lastPage;
+					return loadPosts();
+				}
+			} else {
+				posts = [];
+				postsTotal = 0;
 			}
+		} catch {
+			posts = [];
+			postsTotal = 0;
 		} finally {
 			postsLoading = false;
 		}
@@ -233,11 +256,27 @@
 			const res = await fetch(
 				`/api/admin/users/${encodeURIComponent(userId)}/uploads?page=${uploadsPage}&size=10`
 			);
+			if (!res.ok) {
+				uploads = [];
+				uploadsTotal = 0;
+				return;
+			}
 			const json = await res.json();
 			if (json.status === 'success') {
 				uploads = json.data;
 				uploadsTotal = json.pagination?.total ?? 0;
+				const lastPage = Math.max(1, Math.ceil(uploadsTotal / 10));
+				if (uploadsPage > lastPage) {
+					uploadsPage = lastPage;
+					return loadUploads();
+				}
+			} else {
+				uploads = [];
+				uploadsTotal = 0;
 			}
+		} catch {
+			uploads = [];
+			uploadsTotal = 0;
 		} finally {
 			uploadsLoading = false;
 		}
@@ -283,11 +322,22 @@
 				qs += `&folder_id=${encodeURIComponent(browserFolderId)}`;
 			}
 			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/uploads?${qs}`);
+			if (!res.ok) {
+				browserUploads = [];
+				browserTotal = 0;
+				return;
+			}
 			const json = await res.json();
 			if (json.status === 'success') {
 				browserUploads = json.data;
 				browserTotal = json.pagination?.total ?? 0;
+			} else {
+				browserUploads = [];
+				browserTotal = 0;
 			}
+		} catch {
+			browserUploads = [];
+			browserTotal = 0;
 		} finally {
 			browserLoading = false;
 		}
@@ -320,24 +370,31 @@
 		}
 	}
 
-	// Watch browser sort/page changes
+	// Watch browser sort/page/limit changes
 	let prevBrowserSort = $state<string | undefined>(undefined);
 	let prevBrowserOrder = $state<string | undefined>(undefined);
+	let prevBrowserLimit = $state<number | undefined>(undefined);
 	$effect(() => {
 		if (uploadViewMode !== 'browser') return;
 		const sf = browserSortField;
 		const so = browserSortOrder;
+		const bl = browserLimit;
 		const pg = browserPage;
 		const fid = browserFolderId;
 		void pg;
 		void fid;
-		if (prevBrowserSort !== undefined && prevBrowserOrder !== undefined) {
-			if (prevBrowserSort !== sf || prevBrowserOrder !== so) {
+		if (
+			prevBrowserSort !== undefined &&
+			prevBrowserOrder !== undefined &&
+			prevBrowserLimit !== undefined
+		) {
+			if (prevBrowserSort !== sf || prevBrowserOrder !== so || prevBrowserLimit !== bl) {
 				browserPage = 1;
 			}
 		}
 		prevBrowserSort = sf;
 		prevBrowserOrder = so;
+		prevBrowserLimit = bl;
 		loadBrowserFolders();
 		loadBrowserUploads();
 	});
@@ -482,10 +539,7 @@
 					{@const thisUserPct = Math.min(100, (storage.bytes_limit / cap) * 100)}
 					{@const otherAllocated = instanceOverview.total_allocated - storage.bytes_limit}
 					{@const otherPct = Math.min(100, (otherAllocated / cap) * 100)}
-					{@const totalAllocPct = Math.min(
-						100,
-						((otherAllocated + storage.bytes_limit) / cap) * 100
-					)}
+					{@const rawAllocated = otherAllocated + storage.bytes_limit}
 					<div class="space-y-1 border-t pt-3">
 						<p class="text-xs font-medium text-muted-foreground">Instance capacity</p>
 						<div class="relative h-3 w-full overflow-hidden rounded-full bg-muted">
@@ -509,7 +563,7 @@
 							</span>
 							<span>Total: {formatBytes(cap)}</span>
 						</div>
-						{#if totalAllocPct > 100}
+						{#if rawAllocated > cap}
 							<div class="flex items-center gap-1 text-xs text-destructive">
 								<AlertTriangle class="h-3 w-3" />
 								Over-allocated

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -7,10 +7,15 @@
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { ChevronRight, Home, List, FolderOpen } from 'lucide-svelte';
+	import FileTable from '$lib/components/fragments/file-table.svelte';
+	import FolderCard from '$lib/components/fragments/folder-card.svelte';
+	import { type DisplayItem, uploadsToDisplayItems } from '$lib/types/display-item';
 	import AdminDeleteUserDialog from '$lib/components/fragments/admin-delete-user-dialog.svelte';
 	import AdminDeletePostDialog from '$lib/components/fragments/admin-delete-post-dialog.svelte';
 	import AdminDeleteUploadDialog from '$lib/components/fragments/admin-delete-upload-dialog.svelte';
 	import type { PageData } from './$types';
+	import type { Folder, UploadWithCompositeId } from '@syr-is/types';
 
 	const { data }: { data: PageData } = $props();
 	const userId = $derived(data.userId);
@@ -46,11 +51,13 @@
 		bytes_limit: number;
 		percentage_used: number;
 		bytes_remaining: number;
+		uploads_enabled: boolean;
 	};
 	let storage = $state<StorageInfo | null>(null);
 	let storageLoading = $state(true);
 	let customLimitGb = $state('');
 	let limitSaving = $state(false);
+	let toggleSaving = $state(false);
 
 	async function loadStorage() {
 		storageLoading = true;
@@ -113,6 +120,29 @@
 		}
 	}
 
+	async function toggleUploads() {
+		if (!storage) return;
+		toggleSaving = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/storage`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ uploads_enabled: !storage.uploads_enabled })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to toggle uploads');
+				return;
+			}
+			storage = json.data;
+			toast.success(storage?.uploads_enabled ? 'Uploads enabled' : 'Uploads disabled');
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to toggle');
+		} finally {
+			toggleSaving = false;
+		}
+	}
+
 	// --- Posts ---
 	type PostRow = {
 		id: string;
@@ -145,7 +175,7 @@
 		}
 	}
 
-	// --- Uploads ---
+	// --- Uploads (list view) ---
 	type UploadRow = {
 		id: string;
 		did: string | null;
@@ -155,6 +185,8 @@
 		size: number;
 		status: string;
 		is_public: boolean;
+		key: string | null;
+		folder_id: string | null;
 		created_at: string;
 	};
 	let uploads = $state<UploadRow[]>([]);
@@ -175,6 +207,89 @@
 			}
 		} finally {
 			uploadsLoading = false;
+		}
+	}
+
+	// --- Uploads (browser view) ---
+	let uploadViewMode = $state<'list' | 'browser'>('list');
+	let browserFolderId = $state<string | null>(null);
+	let browserFolders = $state<Folder[]>([]);
+	let browserUploads = $state<UploadWithCompositeId[]>([]);
+	let browserBreadcrumbs = $state<Array<{ id: string; name: string }>>([]);
+	let browserLoading = $state(false);
+	let browserPage = $state(1);
+	let browserTotal = $state(0);
+
+	const browserDisplayItems = $derived(uploadsToDisplayItems(browserFolders, browserUploads));
+	const browserTotalPages = $derived(Math.max(1, Math.ceil(browserTotal / 20)));
+
+	async function loadBrowserFolders() {
+		try {
+			let qs = '';
+			if (browserFolderId) qs = `?parent_id=${encodeURIComponent(browserFolderId)}`;
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/folders${qs}`);
+			const json = await res.json();
+			if (json.status === 'success') {
+				browserFolders = json.data.folders ?? [];
+				browserBreadcrumbs = json.data.breadcrumbs ?? [];
+			}
+		} catch {
+			browserFolders = [];
+		}
+	}
+
+	async function loadBrowserUploads() {
+		browserLoading = true;
+		try {
+			let qs = `page=${browserPage}&size=20&sort_field=created_at&sort_order=desc`;
+			if (browserFolderId === null) {
+				qs += '&folder_id=';
+			} else {
+				qs += `&folder_id=${encodeURIComponent(browserFolderId)}`;
+			}
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/uploads?${qs}`);
+			const json = await res.json();
+			if (json.status === 'success') {
+				browserUploads = json.data;
+				browserTotal = json.pagination?.total ?? 0;
+			}
+		} finally {
+			browserLoading = false;
+		}
+	}
+
+	function navigateFolder(folderId: string | null) {
+		browserFolderId = folderId;
+		browserPage = 1;
+		loadBrowserFolders();
+		loadBrowserUploads();
+	}
+
+	function handleBrowserDelete(item: DisplayItem) {
+		if (item.kind === 'file') {
+			const u = item.data as UploadWithCompositeId;
+			deleteUploadTarget = {
+				did: u.did ?? '',
+				localId: u.local_id ?? '',
+				filename: u.filename
+			};
+			deleteUploadOpen = true;
+		}
+	}
+
+	function handleFolderClick(folder: Folder) {
+		const id = typeof folder.id === 'string' ? folder.id : folder.id.toString();
+		navigateFolder(id);
+	}
+
+	// Switch between list and browser views
+	function switchUploadView(mode: 'list' | 'browser') {
+		uploadViewMode = mode;
+		if (mode === 'browser') {
+			browserFolderId = null;
+			browserPage = 1;
+			loadBrowserFolders();
+			loadBrowserUploads();
 		}
 	}
 
@@ -239,6 +354,15 @@
 		});
 	}
 
+	function extractLocation(key: string | null): string {
+		if (!key) return '/';
+		// key format: uploads/{did}/[folder_path/]{ulid}
+		const parts = key.split('/');
+		// Remove "uploads", DID, and the ULID (last segment)
+		if (parts.length <= 3) return '/';
+		return '/' + parts.slice(2, -1).join('/');
+	}
+
 	const postsTotalPages = $derived(Math.max(1, Math.ceil(postsTotal / 10)));
 	const uploadsTotalPages = $derived(Math.max(1, Math.ceil(uploadsTotal / 10)));
 </script>
@@ -294,7 +418,7 @@
 						{formatBytes(storage.bytes_remaining)} remaining
 					</p>
 				</div>
-				<div class="flex gap-2">
+				<div class="flex flex-wrap gap-2">
 					<Input
 						type="number"
 						min={0.1}
@@ -307,6 +431,20 @@
 					<Button variant="outline" onclick={resetStorageLimit} disabled={limitSaving}>
 						Reset to default
 					</Button>
+				</div>
+				<div class="flex items-center gap-3 border-t pt-3">
+					<span class="text-sm font-medium">File uploads</span>
+					<Button
+						variant={storage.uploads_enabled ? 'default' : 'destructive'}
+						size="sm"
+						onclick={toggleUploads}
+						disabled={toggleSaving}
+					>
+						{storage.uploads_enabled ? 'Enabled' : 'Disabled'}
+					</Button>
+					{#if !storage.uploads_enabled}
+						<span class="text-xs text-muted-foreground">User cannot upload files</span>
+					{/if}
 				</div>
 			{:else if storageLoading}
 				<p class="text-sm text-muted-foreground">Loading…</p>
@@ -371,10 +509,8 @@
 						onclick={() => {
 							postsPage--;
 							loadPosts();
-						}}
+						}}>Prev</Button
 					>
-						Prev
-					</Button>
 					<span class="text-xs text-muted-foreground">{postsPage} / {postsTotalPages}</span>
 					<Button
 						variant="outline"
@@ -383,10 +519,8 @@
 						onclick={() => {
 							postsPage++;
 							loadPosts();
-						}}
+						}}>Next</Button
 					>
-						Next
-					</Button>
 				</div>
 			{/if}
 		</Card.Content>
@@ -395,78 +529,174 @@
 	<!-- Uploads -->
 	<Card.Root>
 		<Card.Header>
-			<Card.Title>Uploads ({uploadsTotal})</Card.Title>
+			<div class="flex items-center justify-between">
+				<Card.Title>Uploads ({uploadsTotal})</Card.Title>
+				<div class="flex gap-1">
+					<Button
+						variant={uploadViewMode === 'list' ? 'default' : 'outline'}
+						size="sm"
+						onclick={() => switchUploadView('list')}
+					>
+						<List class="mr-1 h-3.5 w-3.5" />
+						List
+					</Button>
+					<Button
+						variant={uploadViewMode === 'browser' ? 'default' : 'outline'}
+						size="sm"
+						onclick={() => switchUploadView('browser')}
+					>
+						<FolderOpen class="mr-1 h-3.5 w-3.5" />
+						Browser
+					</Button>
+				</div>
+			</div>
 		</Card.Header>
 		<Card.Content>
-			<Table.Root>
-				<Table.Header>
-					<Table.Row>
-						<Table.Head>Filename</Table.Head>
-						<Table.Head>Size</Table.Head>
-						<Table.Head>Status</Table.Head>
-						<Table.Head>Public</Table.Head>
-						<Table.Head>Created</Table.Head>
-						<Table.Head class="text-right">Actions</Table.Head>
-					</Table.Row>
-				</Table.Header>
-				<Table.Body>
-					{#if uploadsLoading}
+			{#if uploadViewMode === 'list'}
+				<!-- Flat list view with location column -->
+				<Table.Root>
+					<Table.Header>
 						<Table.Row>
-							<Table.Cell colspan={6} class="py-4 text-center text-muted-foreground">
-								Loading…
-							</Table.Cell>
+							<Table.Head>Filename</Table.Head>
+							<Table.Head>Location</Table.Head>
+							<Table.Head>Size</Table.Head>
+							<Table.Head>Status</Table.Head>
+							<Table.Head>Public</Table.Head>
+							<Table.Head>Created</Table.Head>
+							<Table.Head class="text-right">Actions</Table.Head>
 						</Table.Row>
-					{:else if uploads.length === 0}
-						<Table.Row>
-							<Table.Cell colspan={6} class="py-4 text-center text-muted-foreground">
-								No uploads.
-							</Table.Cell>
-						</Table.Row>
-					{:else}
-						{#each uploads as upload (upload.id)}
+					</Table.Header>
+					<Table.Body>
+						{#if uploadsLoading}
 							<Table.Row>
-								<Table.Cell class="max-w-[200px] truncate text-sm">{upload.filename}</Table.Cell>
-								<Table.Cell class="text-xs">{formatBytes(upload.size)}</Table.Cell>
-								<Table.Cell class="text-xs">{upload.status}</Table.Cell>
-								<Table.Cell class="text-xs">{upload.is_public ? 'Yes' : 'No'}</Table.Cell>
-								<Table.Cell class="text-xs text-muted-foreground">
-									{formatDate(upload.created_at)}
-								</Table.Cell>
-								<Table.Cell class="text-right">
-									<Button variant="destructive" size="sm" onclick={() => openDeleteUpload(upload)}>
-										Delete
-									</Button>
-								</Table.Cell>
+								<Table.Cell colspan={7} class="py-4 text-center text-muted-foreground"
+									>Loading…</Table.Cell
+								>
 							</Table.Row>
+						{:else if uploads.length === 0}
+							<Table.Row>
+								<Table.Cell colspan={7} class="py-4 text-center text-muted-foreground"
+									>No uploads.</Table.Cell
+								>
+							</Table.Row>
+						{:else}
+							{#each uploads as upload (upload.id)}
+								<Table.Row>
+									<Table.Cell class="max-w-[200px] truncate text-sm">{upload.filename}</Table.Cell>
+									<Table.Cell class="max-w-[150px] truncate font-mono text-xs text-muted-foreground"
+										>{extractLocation(upload.key)}</Table.Cell
+									>
+									<Table.Cell class="text-xs">{formatBytes(upload.size)}</Table.Cell>
+									<Table.Cell class="text-xs">{upload.status}</Table.Cell>
+									<Table.Cell class="text-xs">{upload.is_public ? 'Yes' : 'No'}</Table.Cell>
+									<Table.Cell class="text-xs text-muted-foreground"
+										>{formatDate(upload.created_at)}</Table.Cell
+									>
+									<Table.Cell class="text-right">
+										<Button variant="destructive" size="sm" onclick={() => openDeleteUpload(upload)}
+											>Delete</Button
+										>
+									</Table.Cell>
+								</Table.Row>
+							{/each}
+						{/if}
+					</Table.Body>
+				</Table.Root>
+				{#if uploadsTotalPages > 1}
+					<div class="mt-2 flex items-center justify-end gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={uploadsPage <= 1}
+							onclick={() => {
+								uploadsPage--;
+								loadUploads();
+							}}>Prev</Button
+						>
+						<span class="text-xs text-muted-foreground">{uploadsPage} / {uploadsTotalPages}</span>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={uploadsPage >= uploadsTotalPages}
+							onclick={() => {
+								uploadsPage++;
+								loadUploads();
+							}}>Next</Button
+						>
+					</div>
+				{/if}
+			{:else}
+				<!-- File browser view -->
+				<div class="space-y-3">
+					<!-- Breadcrumbs -->
+					<nav class="flex items-center gap-1 text-sm">
+						<button
+							type="button"
+							class="text-muted-foreground hover:text-foreground"
+							onclick={() => navigateFolder(null)}
+						>
+							<Home class="h-4 w-4" />
+						</button>
+						{#each browserBreadcrumbs as crumb (crumb.id)}
+							<ChevronRight class="h-3.5 w-3.5 text-muted-foreground" />
+							<button
+								type="button"
+								class="text-sm text-muted-foreground hover:text-foreground"
+								onclick={() => navigateFolder(crumb.id)}
+							>
+								{crumb.name}
+							</button>
 						{/each}
+					</nav>
+
+					{#if browserLoading}
+						<p class="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+					{:else}
+						<!-- Folders -->
+						{#if browserFolders.length > 0}
+							<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+								{#each browserFolders as folder (folder.id)}
+									<FolderCard {folder} onclick={() => handleFolderClick(folder)} />
+								{/each}
+							</div>
+						{/if}
+
+						<!-- Files -->
+						{#if browserDisplayItems.filter((i) => i.kind === 'file').length > 0}
+							<FileTable
+								items={browserDisplayItems.filter((i) => i.kind === 'file')}
+								onDelete={handleBrowserDelete}
+							/>
+						{:else if browserFolders.length === 0}
+							<p class="py-4 text-center text-sm text-muted-foreground">Empty folder.</p>
+						{/if}
+
+						{#if browserTotalPages > 1}
+							<div class="flex items-center justify-end gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={browserPage <= 1}
+									onclick={() => {
+										browserPage--;
+										loadBrowserUploads();
+									}}>Prev</Button
+								>
+								<span class="text-xs text-muted-foreground"
+									>{browserPage} / {browserTotalPages}</span
+								>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={browserPage >= browserTotalPages}
+									onclick={() => {
+										browserPage++;
+										loadBrowserUploads();
+									}}>Next</Button
+								>
+							</div>
+						{/if}
 					{/if}
-				</Table.Body>
-			</Table.Root>
-			{#if uploadsTotalPages > 1}
-				<div class="mt-2 flex items-center justify-end gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={uploadsPage <= 1}
-						onclick={() => {
-							uploadsPage--;
-							loadUploads();
-						}}
-					>
-						Prev
-					</Button>
-					<span class="text-xs text-muted-foreground">{uploadsPage} / {uploadsTotalPages}</span>
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={uploadsPage >= uploadsTotalPages}
-						onclick={() => {
-							uploadsPage++;
-							loadUploads();
-						}}
-					>
-						Next
-					</Button>
 				</div>
 			{/if}
 		</Card.Content>
@@ -498,5 +728,9 @@
 	onSuccess={() => {
 		loadUploads();
 		loadStorage();
+		if (uploadViewMode === 'browser') {
+			loadBrowserFolders();
+			loadBrowserUploads();
+		}
 	}}
 />

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -439,7 +439,22 @@
 	// --- Init ---
 	$effect(() => {
 		if (userId) {
-			// Reset all pagination and state when switching users
+			// Clear all data and close dialogs when switching users
+			storage = null;
+			instanceOverview = null;
+			posts = [];
+			postsTotal = 0;
+			uploads = [];
+			uploadsTotal = 0;
+			browserFolders = [];
+			browserUploads = [];
+			browserBreadcrumbs = [];
+			browserTotal = 0;
+			deleteUserOpen = false;
+			deletePostOpen = false;
+			deleteUploadOpen = false;
+
+			// Reset pagination
 			postsPage = 1;
 			uploadsPage = 1;
 			browserFolderId = null;

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -1,0 +1,502 @@
+<script lang="ts">
+	import * as Card from '@syr-is/ui/card';
+	import * as Table from '@syr-is/ui/table';
+	import { Button } from '@syr-is/ui/button';
+	import { Input } from '@syr-is/ui/input';
+	import { Progress } from '@syr-is/ui/progress';
+	import { toast } from 'svelte-sonner';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import AdminDeleteUserDialog from '$lib/components/fragments/admin-delete-user-dialog.svelte';
+	import AdminDeletePostDialog from '$lib/components/fragments/admin-delete-post-dialog.svelte';
+	import AdminDeleteUploadDialog from '$lib/components/fragments/admin-delete-upload-dialog.svelte';
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+	const userId = $derived(data.userId);
+
+	// --- User info ---
+	type UserInfo = {
+		id: string;
+		username: string;
+		did: string | null;
+		role: string;
+		created_at: string;
+		updated_at: string;
+		display_name: string;
+		bio: string | null;
+	};
+	let userInfo = $state<UserInfo | null>(null);
+	let _userLoading = $state(true);
+
+	async function loadUser() {
+		_userLoading = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}`);
+			const json = await res.json();
+			if (json.status === 'success') userInfo = json.data;
+		} finally {
+			_userLoading = false;
+		}
+	}
+
+	// --- Storage ---
+	type StorageInfo = {
+		bytes_used: number;
+		bytes_limit: number;
+		percentage_used: number;
+		bytes_remaining: number;
+	};
+	let storage = $state<StorageInfo | null>(null);
+	let storageLoading = $state(true);
+	let customLimitGb = $state('');
+	let limitSaving = $state(false);
+
+	async function loadStorage() {
+		storageLoading = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/storage`);
+			const json = await res.json();
+			if (json.status === 'success') storage = json.data;
+		} finally {
+			storageLoading = false;
+		}
+	}
+
+	async function setStorageLimit() {
+		const gb = parseFloat(customLimitGb);
+		if (isNaN(gb) || gb <= 0) {
+			toast.error('Enter a valid number of GB');
+			return;
+		}
+		limitSaving = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/storage`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ bytes_limit: Math.round(gb * 1024 * 1024 * 1024) })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to set limit');
+				return;
+			}
+			storage = json.data;
+			customLimitGb = '';
+			toast.success('Storage limit updated');
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to set limit');
+		} finally {
+			limitSaving = false;
+		}
+	}
+
+	async function resetStorageLimit() {
+		limitSaving = true;
+		try {
+			const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}/storage`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ reset: true })
+			});
+			const json = await res.json();
+			if (!res.ok) {
+				toast.error(json.message ?? 'Failed to reset');
+				return;
+			}
+			storage = json.data;
+			toast.success('Storage limit reset to default');
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Failed to reset');
+		} finally {
+			limitSaving = false;
+		}
+	}
+
+	// --- Posts ---
+	type PostRow = {
+		id: string;
+		did: string | null;
+		local_id: string | null;
+		type: string;
+		title: string | null;
+		visibility: string;
+		status: string;
+		created_at: string;
+	};
+	let posts = $state<PostRow[]>([]);
+	let postsTotal = $state(0);
+	let postsPage = $state(1);
+	let postsLoading = $state(true);
+
+	async function loadPosts() {
+		postsLoading = true;
+		try {
+			const res = await fetch(
+				`/api/admin/users/${encodeURIComponent(userId)}/posts?page=${postsPage}&size=10`
+			);
+			const json = await res.json();
+			if (json.status === 'success') {
+				posts = json.data;
+				postsTotal = json.pagination?.total ?? 0;
+			}
+		} finally {
+			postsLoading = false;
+		}
+	}
+
+	// --- Uploads ---
+	type UploadRow = {
+		id: string;
+		did: string | null;
+		local_id: string | null;
+		filename: string;
+		mime_type: string;
+		size: number;
+		status: string;
+		is_public: boolean;
+		created_at: string;
+	};
+	let uploads = $state<UploadRow[]>([]);
+	let uploadsTotal = $state(0);
+	let uploadsPage = $state(1);
+	let uploadsLoading = $state(true);
+
+	async function loadUploads() {
+		uploadsLoading = true;
+		try {
+			const res = await fetch(
+				`/api/admin/users/${encodeURIComponent(userId)}/uploads?page=${uploadsPage}&size=10`
+			);
+			const json = await res.json();
+			if (json.status === 'success') {
+				uploads = json.data;
+				uploadsTotal = json.pagination?.total ?? 0;
+			}
+		} finally {
+			uploadsLoading = false;
+		}
+	}
+
+	// --- Dialogs ---
+	let deleteUserOpen = $state(false);
+	let deletePostOpen = $state(false);
+	let deletePostTarget = $state<{ did: string; localId: string; title: string | null }>({
+		did: '',
+		localId: '',
+		title: null
+	});
+	let deleteUploadOpen = $state(false);
+	let deleteUploadTarget = $state<{ did: string; localId: string; filename: string | null }>({
+		did: '',
+		localId: '',
+		filename: null
+	});
+
+	function openDeletePost(post: PostRow) {
+		deletePostTarget = { did: post.did ?? '', localId: post.local_id ?? '', title: post.title };
+		deletePostOpen = true;
+	}
+
+	function openDeleteUpload(upload: UploadRow) {
+		deleteUploadTarget = {
+			did: upload.did ?? '',
+			localId: upload.local_id ?? '',
+			filename: upload.filename
+		};
+		deleteUploadOpen = true;
+	}
+
+	// --- Init ---
+	$effect(() => {
+		if (userId) {
+			loadUser();
+			loadStorage();
+		}
+	});
+
+	$effect(() => {
+		if (userId) loadPosts();
+	});
+
+	$effect(() => {
+		if (userId) loadUploads();
+	});
+
+	function formatBytes(bytes: number): string {
+		if (bytes === 0) return '0 B';
+		const k = 1024;
+		const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+		const i = Math.floor(Math.log(bytes) / Math.log(k));
+		return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+	}
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+
+	const postsTotalPages = $derived(Math.max(1, Math.ceil(postsTotal / 10)));
+	const uploadsTotalPages = $derived(Math.max(1, Math.ceil(uploadsTotal / 10)));
+</script>
+
+<svelte:head>
+	<title>{userInfo?.username ?? 'User'} | Users | Settings | SYR</title>
+</svelte:head>
+
+<div class="mx-auto max-w-4xl space-y-6">
+	<a href={resolve('/settings/users')} class="text-sm text-muted-foreground hover:text-foreground">
+		&larr; Back to users
+	</a>
+
+	<!-- User Info -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>{userInfo?.display_name ?? 'Loading…'}</Card.Title>
+			{#if userInfo}
+				<Card.Description>@{userInfo.username}</Card.Description>
+			{/if}
+		</Card.Header>
+		{#if userInfo}
+			<Card.Content class="space-y-2 text-sm">
+				<div><strong>DID:</strong> <code class="text-xs">{userInfo.did ?? '—'}</code></div>
+				<div><strong>Role:</strong> {userInfo.role}</div>
+				<div><strong>Created:</strong> {formatDate(userInfo.created_at)}</div>
+				{#if userInfo.bio}
+					<div><strong>Bio:</strong> {userInfo.bio}</div>
+				{/if}
+			</Card.Content>
+			<Card.Footer>
+				<Button variant="destructive" onclick={() => (deleteUserOpen = true)}>
+					Delete account
+				</Button>
+			</Card.Footer>
+		{/if}
+	</Card.Root>
+
+	<!-- Storage -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Storage</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			{#if storage}
+				<div class="space-y-1">
+					<div class="flex justify-between text-sm">
+						<span>{formatBytes(storage.bytes_used)} used</span>
+						<span>{formatBytes(storage.bytes_limit)} limit</span>
+					</div>
+					<Progress value={storage.percentage_used} />
+					<p class="text-xs text-muted-foreground">
+						{formatBytes(storage.bytes_remaining)} remaining
+					</p>
+				</div>
+				<div class="flex gap-2">
+					<Input
+						type="number"
+						min={0.1}
+						step={0.1}
+						placeholder="GB"
+						class="max-w-[8rem]"
+						bind:value={customLimitGb}
+					/>
+					<Button onclick={setStorageLimit} disabled={limitSaving}>Set limit (GB)</Button>
+					<Button variant="outline" onclick={resetStorageLimit} disabled={limitSaving}>
+						Reset to default
+					</Button>
+				</div>
+			{:else if storageLoading}
+				<p class="text-sm text-muted-foreground">Loading…</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<!-- Posts -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Posts ({postsTotal})</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<Table.Root>
+				<Table.Header>
+					<Table.Row>
+						<Table.Head>Title / Type</Table.Head>
+						<Table.Head>Visibility</Table.Head>
+						<Table.Head>Status</Table.Head>
+						<Table.Head>Created</Table.Head>
+						<Table.Head class="text-right">Actions</Table.Head>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{#if postsLoading}
+						<Table.Row>
+							<Table.Cell colspan={5} class="py-4 text-center text-muted-foreground">
+								Loading…
+							</Table.Cell>
+						</Table.Row>
+					{:else if posts.length === 0}
+						<Table.Row>
+							<Table.Cell colspan={5} class="py-4 text-center text-muted-foreground">
+								No posts.
+							</Table.Cell>
+						</Table.Row>
+					{:else}
+						{#each posts as post (post.id)}
+							<Table.Row>
+								<Table.Cell>{post.title || post.type}</Table.Cell>
+								<Table.Cell class="text-xs">{post.visibility}</Table.Cell>
+								<Table.Cell class="text-xs">{post.status}</Table.Cell>
+								<Table.Cell class="text-xs text-muted-foreground">
+									{formatDate(post.created_at)}
+								</Table.Cell>
+								<Table.Cell class="text-right">
+									<Button variant="destructive" size="sm" onclick={() => openDeletePost(post)}>
+										Delete
+									</Button>
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					{/if}
+				</Table.Body>
+			</Table.Root>
+			{#if postsTotalPages > 1}
+				<div class="mt-2 flex items-center justify-end gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={postsPage <= 1}
+						onclick={() => {
+							postsPage--;
+							loadPosts();
+						}}
+					>
+						Prev
+					</Button>
+					<span class="text-xs text-muted-foreground">{postsPage} / {postsTotalPages}</span>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={postsPage >= postsTotalPages}
+						onclick={() => {
+							postsPage++;
+							loadPosts();
+						}}
+					>
+						Next
+					</Button>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<!-- Uploads -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Uploads ({uploadsTotal})</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<Table.Root>
+				<Table.Header>
+					<Table.Row>
+						<Table.Head>Filename</Table.Head>
+						<Table.Head>Size</Table.Head>
+						<Table.Head>Status</Table.Head>
+						<Table.Head>Public</Table.Head>
+						<Table.Head>Created</Table.Head>
+						<Table.Head class="text-right">Actions</Table.Head>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{#if uploadsLoading}
+						<Table.Row>
+							<Table.Cell colspan={6} class="py-4 text-center text-muted-foreground">
+								Loading…
+							</Table.Cell>
+						</Table.Row>
+					{:else if uploads.length === 0}
+						<Table.Row>
+							<Table.Cell colspan={6} class="py-4 text-center text-muted-foreground">
+								No uploads.
+							</Table.Cell>
+						</Table.Row>
+					{:else}
+						{#each uploads as upload (upload.id)}
+							<Table.Row>
+								<Table.Cell class="max-w-[200px] truncate text-sm">{upload.filename}</Table.Cell>
+								<Table.Cell class="text-xs">{formatBytes(upload.size)}</Table.Cell>
+								<Table.Cell class="text-xs">{upload.status}</Table.Cell>
+								<Table.Cell class="text-xs">{upload.is_public ? 'Yes' : 'No'}</Table.Cell>
+								<Table.Cell class="text-xs text-muted-foreground">
+									{formatDate(upload.created_at)}
+								</Table.Cell>
+								<Table.Cell class="text-right">
+									<Button variant="destructive" size="sm" onclick={() => openDeleteUpload(upload)}>
+										Delete
+									</Button>
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					{/if}
+				</Table.Body>
+			</Table.Root>
+			{#if uploadsTotalPages > 1}
+				<div class="mt-2 flex items-center justify-end gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={uploadsPage <= 1}
+						onclick={() => {
+							uploadsPage--;
+							loadUploads();
+						}}
+					>
+						Prev
+					</Button>
+					<span class="text-xs text-muted-foreground">{uploadsPage} / {uploadsTotalPages}</span>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={uploadsPage >= uploadsTotalPages}
+						onclick={() => {
+							uploadsPage++;
+							loadUploads();
+						}}
+					>
+						Next
+					</Button>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+</div>
+
+<AdminDeleteUserDialog
+	bind:open={deleteUserOpen}
+	{userId}
+	username={userInfo?.username}
+	onSuccess={() => goto(resolve('/settings/users'))}
+/>
+
+<AdminDeletePostDialog
+	bind:open={deletePostOpen}
+	{userId}
+	postDid={deletePostTarget.did}
+	postLocalId={deletePostTarget.localId}
+	postTitle={deletePostTarget.title}
+	onSuccess={() => loadPosts()}
+/>
+
+<AdminDeleteUploadDialog
+	bind:open={deleteUploadOpen}
+	{userId}
+	uploadDid={deleteUploadTarget.did}
+	uploadLocalId={deleteUploadTarget.localId}
+	filename={deleteUploadTarget.filename}
+	onSuccess={() => {
+		loadUploads();
+		loadStorage();
+	}}
+/>

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -494,7 +494,7 @@
 								style="width: {thisUserPct}%"
 							></div>
 							<div
-								class="absolute inset-y-0 bg-muted-foreground/20"
+								class="absolute inset-y-0 rounded-full bg-muted-foreground/20"
 								style="left: {thisUserPct}%; width: {otherPct}%"
 							></div>
 						</div>

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -7,10 +7,8 @@
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { ChevronRight, Home, List, FolderOpen, ExternalLink } from 'lucide-svelte';
-	import FileTable from '$lib/components/fragments/file-table.svelte';
-	import FolderCard from '$lib/components/fragments/folder-card.svelte';
-	import { type DisplayItem, uploadsToDisplayItems } from '$lib/types/display-item';
+	import { List, FolderOpen, ExternalLink } from 'lucide-svelte';
+	import FileBrowser from '$lib/components/fragments/file-browser.svelte';
 	import AdminDeleteUserDialog from '$lib/components/fragments/admin-delete-user-dialog.svelte';
 	import AdminDeletePostDialog from '$lib/components/fragments/admin-delete-post-dialog.svelte';
 	import AdminDeleteUploadDialog from '$lib/components/fragments/admin-delete-upload-dialog.svelte';
@@ -219,10 +217,12 @@
 	let browserBreadcrumbs = $state<Array<{ id: string; name: string }>>([]);
 	let browserLoading = $state(false);
 	let browserPage = $state(1);
+	let browserLimit = $state(20);
 	let browserTotal = $state(0);
-
-	const browserDisplayItems = $derived(uploadsToDisplayItems(browserFolders, browserUploads));
-	const browserTotalPages = $derived(Math.max(1, Math.ceil(browserTotal / 20)));
+	let browserSortField = $state<'created_at' | 'updated_at' | 'filename' | 'size'>('created_at');
+	let browserSortOrder = $state<'asc' | 'desc'>('desc');
+	import type { ViewMode } from '$lib/types/display-item';
+	let browserViewMode = $state<ViewMode>('list');
 
 	async function loadBrowserFolders() {
 		try {
@@ -242,7 +242,7 @@
 	async function loadBrowserUploads() {
 		browserLoading = true;
 		try {
-			let qs = `page=${browserPage}&size=20&sort_field=created_at&sort_order=desc`;
+			let qs = `page=${browserPage}&size=${browserLimit}&sort_field=${browserSortField}&sort_order=${browserSortOrder}`;
 			if (browserFolderId === null) {
 				qs += '&folder_id=';
 			} else {
@@ -266,24 +266,15 @@
 		loadBrowserUploads();
 	}
 
-	function handleBrowserDelete(item: DisplayItem) {
-		if (item.kind === 'file') {
-			const u = item.data as UploadWithCompositeId;
-			deleteUploadTarget = {
-				did: u.did ?? '',
-				localId: u.local_id ?? '',
-				filename: u.filename
-			};
-			deleteUploadOpen = true;
-		}
+	function handleBrowserDelete(upload: UploadWithCompositeId) {
+		deleteUploadTarget = {
+			did: upload.did ?? '',
+			localId: upload.local_id ?? '',
+			filename: upload.filename
+		};
+		deleteUploadOpen = true;
 	}
 
-	function handleFolderClick(folder: Folder) {
-		const id = typeof folder.id === 'string' ? folder.id : folder.id.toString();
-		navigateFolder(id);
-	}
-
-	// Switch between list and browser views
 	function switchUploadView(mode: 'list' | 'browser') {
 		uploadViewMode = mode;
 		if (mode === 'browser') {
@@ -293,6 +284,28 @@
 			loadBrowserUploads();
 		}
 	}
+
+	// Watch browser sort/page changes
+	let prevBrowserSort = $state<string | undefined>(undefined);
+	let prevBrowserOrder = $state<string | undefined>(undefined);
+	$effect(() => {
+		if (uploadViewMode !== 'browser') return;
+		const sf = browserSortField;
+		const so = browserSortOrder;
+		const pg = browserPage;
+		const fid = browserFolderId;
+		void pg;
+		void fid;
+		if (prevBrowserSort !== undefined && prevBrowserOrder !== undefined) {
+			if (prevBrowserSort !== sf || prevBrowserOrder !== so) {
+				browserPage = 1;
+			}
+		}
+		prevBrowserSort = sf;
+		prevBrowserOrder = so;
+		loadBrowserFolders();
+		loadBrowserUploads();
+	});
 
 	// --- Dialogs ---
 	let deleteUserOpen = $state(false);
@@ -655,78 +668,21 @@
 					</div>
 				{/if}
 			{:else}
-				<!-- File browser view -->
-				<div class="space-y-3">
-					<!-- Breadcrumbs -->
-					<nav class="flex items-center gap-1 text-sm">
-						<button
-							type="button"
-							class="text-muted-foreground hover:text-foreground"
-							onclick={() => navigateFolder(null)}
-						>
-							<Home class="h-4 w-4" />
-						</button>
-						{#each browserBreadcrumbs as crumb (crumb.id)}
-							<ChevronRight class="h-3.5 w-3.5 text-muted-foreground" />
-							<button
-								type="button"
-								class="text-sm text-muted-foreground hover:text-foreground"
-								onclick={() => navigateFolder(crumb.id)}
-							>
-								{crumb.name}
-							</button>
-						{/each}
-					</nav>
-
-					{#if browserLoading}
-						<p class="py-4 text-center text-sm text-muted-foreground">Loading…</p>
-					{:else}
-						<!-- Folders -->
-						{#if browserFolders.length > 0}
-							<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
-								{#each browserFolders as folder (folder.id)}
-									<FolderCard {folder} onclick={() => handleFolderClick(folder)} />
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Files -->
-						{#if browserDisplayItems.filter((i) => i.kind === 'file').length > 0}
-							<FileTable
-								items={browserDisplayItems.filter((i) => i.kind === 'file')}
-								onDelete={handleBrowserDelete}
-							/>
-						{:else if browserFolders.length === 0}
-							<p class="py-4 text-center text-sm text-muted-foreground">Empty folder.</p>
-						{/if}
-
-						{#if browserTotalPages > 1}
-							<div class="flex items-center justify-end gap-2">
-								<Button
-									variant="outline"
-									size="sm"
-									disabled={browserPage <= 1}
-									onclick={() => {
-										browserPage--;
-										loadBrowserUploads();
-									}}>Prev</Button
-								>
-								<span class="text-xs text-muted-foreground"
-									>{browserPage} / {browserTotalPages}</span
-								>
-								<Button
-									variant="outline"
-									size="sm"
-									disabled={browserPage >= browserTotalPages}
-									onclick={() => {
-										browserPage++;
-										loadBrowserUploads();
-									}}>Next</Button
-								>
-							</div>
-						{/if}
-					{/if}
-				</div>
+				<FileBrowser
+					folders={browserFolders}
+					uploads={browserUploads}
+					breadcrumbs={browserBreadcrumbs}
+					loading={browserLoading}
+					total={browserTotal}
+					bind:viewMode={browserViewMode}
+					bind:currentPage={browserPage}
+					bind:limit={browserLimit}
+					bind:sortField={browserSortField}
+					bind:sortOrder={browserSortOrder}
+					readonly
+					onNavigateFolder={navigateFolder}
+					onDeleteUpload={handleBrowserDelete}
+				/>
 			{/if}
 		</Card.Content>
 	</Card.Root>

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -490,12 +490,12 @@
 						<p class="text-xs font-medium text-muted-foreground">Instance capacity</p>
 						<div class="relative h-3 w-full overflow-hidden rounded-full bg-muted">
 							<div
-								class="absolute inset-y-0 left-0 rounded-full bg-muted-foreground/20"
-								style="width: {Math.min(100, otherPct + thisUserPct)}%"
+								class="absolute inset-y-0 left-0 rounded-full bg-primary"
+								style="width: {thisUserPct}%"
 							></div>
 							<div
-								class="absolute inset-y-0 rounded-full bg-primary"
-								style="left: {otherPct}%; width: {thisUserPct}%"
+								class="absolute inset-y-0 bg-muted-foreground/20"
+								style="left: {thisUserPct}%; width: {otherPct}%"
 							></div>
 						</div>
 						<div class="flex items-center gap-3 text-xs text-muted-foreground">

--- a/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/settings/users/[userId]/+page.svelte
@@ -7,7 +7,7 @@
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { ChevronRight, Home, List, FolderOpen } from 'lucide-svelte';
+	import { ChevronRight, Home, List, FolderOpen, ExternalLink } from 'lucide-svelte';
 	import FileTable from '$lib/components/fragments/file-table.svelte';
 	import FolderCard from '$lib/components/fragments/folder-card.svelte';
 	import { type DisplayItem, uploadsToDisplayItems } from '$lib/types/display-item';
@@ -187,6 +187,7 @@
 		is_public: boolean;
 		key: string | null;
 		folder_id: string | null;
+		url: string | null;
 		created_at: string;
 	};
 	let uploads = $state<UploadRow[]>([]);
@@ -491,9 +492,22 @@
 									{formatDate(post.created_at)}
 								</Table.Cell>
 								<Table.Cell class="text-right">
-									<Button variant="destructive" size="sm" onclick={() => openDeletePost(post)}>
-										Delete
-									</Button>
+									<div class="flex items-center justify-end gap-1">
+										{#if post.did && post.local_id}
+											<a
+												href={resolve(`/posts/${post.did}/${post.local_id}`)}
+												target="_blank"
+												rel="noopener"
+												class="inline-flex h-8 items-center rounded-md border border-input bg-background px-2.5 text-xs font-medium shadow-xs hover:bg-accent hover:text-accent-foreground"
+											>
+												<ExternalLink class="mr-1 h-3 w-3" />
+												View
+											</a>
+										{/if}
+										<Button variant="destructive" size="sm" onclick={() => openDeletePost(post)}>
+											Delete
+										</Button>
+									</div>
 								</Table.Cell>
 							</Table.Row>
 						{/each}
@@ -593,9 +607,24 @@
 										>{formatDate(upload.created_at)}</Table.Cell
 									>
 									<Table.Cell class="text-right">
-										<Button variant="destructive" size="sm" onclick={() => openDeleteUpload(upload)}
-											>Delete</Button
-										>
+										<div class="flex items-center justify-end gap-1">
+											{#if upload.url && upload.status === 'completed'}
+												<a
+													href={upload.url}
+													target="_blank"
+													rel="noopener"
+													class="inline-flex h-8 items-center rounded-md border border-input bg-background px-2.5 text-xs font-medium shadow-xs hover:bg-accent hover:text-accent-foreground"
+												>
+													<ExternalLink class="mr-1 h-3 w-3" />
+													View
+												</a>
+											{/if}
+											<Button
+												variant="destructive"
+												size="sm"
+												onclick={() => openDeleteUpload(upload)}>Delete</Button
+											>
+										</div>
 									</Table.Cell>
 								</Table.Row>
 							{/each}

--- a/apps/syr/app/src/routes/(private)/uploads/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/uploads/+page.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 	import * as Card from '@syr-is/ui/card';
-	import * as Select from '@syr-is/ui/select';
-	import * as Pagination from '@syr-is/ui/pagination';
 	import { Button } from '@syr-is/ui/button';
-	import { Skeleton } from '@syr-is/ui/skeleton';
 	import { getUploadApiUrl, type UploadWithCompositeId, type Folder } from '@syr-is/types';
 	import { replaceState } from '$app/navigation';
 	import { page } from '$app/stores';
 
-	// Dialog components
 	import DeleteUploadDialog from '$lib/components/fragments/delete-upload-dialog.svelte';
 	import UploadFilesDialog from '$lib/components/fragments/upload-files-dialog.svelte';
 	import CreateFolderDialog from '$lib/components/fragments/create-folder-dialog.svelte';
@@ -17,22 +13,12 @@
 	import RenameUploadDialog from '$lib/components/fragments/rename-upload-dialog.svelte';
 	import ShareUploadDialog from '$lib/components/fragments/share-upload-dialog.svelte';
 	import MediaPreviewModal from '$lib/components/fragments/media-preview-modal.svelte';
+	import FileBrowser from '$lib/components/fragments/file-browser.svelte';
 	import { toast } from 'svelte-sonner';
-	import { Plus, FolderPlus, ChevronRight, Home, File } from 'lucide-svelte';
+	import { Plus, FolderPlus } from 'lucide-svelte';
 
-	// Shared view components
-	import ViewModeToggle from '$lib/components/fragments/view-mode-toggle.svelte';
-	import FileTable from '$lib/components/fragments/file-table.svelte';
-	import FileGrid from '$lib/components/fragments/file-grid.svelte';
-	import FileCarousel from '$lib/components/fragments/file-carousel.svelte';
-	import MediaCardGrid from '$lib/components/fragments/media-card-grid.svelte';
-	import FolderCard from '$lib/components/fragments/folder-card.svelte';
-	import {
-		type ViewMode,
-		type DisplayItem,
-		uploadsToDisplayItems,
-		getFileItems
-	} from '$lib/types/display-item';
+	import type { ViewMode, DisplayItem } from '$lib/types/display-item';
+	import { getFileItems, uploadsToDisplayItems } from '$lib/types/display-item';
 
 	let { data } = $props();
 
@@ -45,7 +31,7 @@
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 
-	// Current folder state - sync from server data; writable for user navigation (setFolder, etc.)
+	// Current folder state
 	// eslint-disable-next-line svelte/prefer-writable-derived -- need writable for folder navigation
 	let currentFolderId = $state<string | null>(null);
 	let breadcrumbs = $state<Array<{ id: string; name: string }>>([]);
@@ -53,11 +39,9 @@
 		currentFolderId = data.initialFolderId ?? null;
 	});
 
-	// Show toast if path was invalid
 	$effect(() => {
 		if (data.invalidPath) {
 			toast.error('Folder not found or access denied. Redirected to root.');
-			// Clear the invalid path from URL (same page, just clearing query param)
 			// eslint-disable-next-line svelte/no-navigation-without-resolve
 			replaceState($page.url.pathname, {});
 		}
@@ -75,45 +59,33 @@
 	// Dialog states
 	let deleteUploadDialogOpen = $state(false);
 	let uploadToDelete = $state<UploadWithCompositeId | null>(null);
-
 	let deleteFolderDialogOpen = $state(false);
 	let folderToDelete = $state<Folder | null>(null);
-
 	let uploadDialogOpen = $state(false);
-
 	let createFolderDialogOpen = $state(false);
-
 	let moveDialogOpen = $state(false);
 	let uploadToMove = $state<UploadWithCompositeId | null>(null);
-
 	let renameDialogOpen = $state(false);
 	let uploadToRename = $state<UploadWithCompositeId | null>(null);
-
 	let shareDialogOpen = $state(false);
 	let uploadToShare = $state<UploadWithCompositeId | null>(null);
-
-	// Media preview modal for visual browsing (gallery/masonry modes)
 	let mediaPreviewOpen = $state(false);
 	let mediaPreviewIndex = $state(0);
 
-	// Computed DisplayItems for shared components
-	const displayItems = $derived(uploadsToDisplayItems(folders, uploads));
-	const fileDisplayItems = $derived(getFileItems(displayItems));
+	const fileDisplayItems = $derived(getFileItems(uploadsToDisplayItems(folders, uploads)));
+
+	const isInPublicFolder = $derived(breadcrumbs.some((b) => b.name.toLowerCase() === 'public'));
 
 	// Fetch folders
 	async function fetchFolders() {
 		if (!data.user) return;
-
 		try {
 			let queryString = '';
 			if (currentFolderId) {
 				queryString = `?parent_id=${encodeURIComponent(currentFolderId)}`;
 			}
-
 			const response = await fetch(`/api/folders${queryString}`);
 			if (!response.ok) {
-				const errorData = await response.json();
-				// If folder not found or access denied, reset to root
 				if (response.status === 404 || response.status === 403 || response.status === 400) {
 					if (currentFolderId) {
 						toast.error('Folder not found or access denied. Redirected to root.');
@@ -122,15 +94,14 @@
 						return;
 					}
 				}
+				const errorData = await response.json();
 				throw new Error(errorData.error?.message || 'Failed to fetch folders');
 			}
-
 			const result = await response.json();
 			folders = result.data?.folders || [];
 			breadcrumbs = result.data?.breadcrumbs || [];
 		} catch (err) {
 			console.error('Failed to fetch folders:', err);
-			// If there was an error and we're in a folder, try resetting to root
 			if (currentFolderId) {
 				toast.error('Failed to load folder. Redirected to root.');
 				currentFolderId = null;
@@ -141,10 +112,9 @@
 		}
 	}
 
-	// Fetch uploads function
+	// Fetch uploads
 	async function fetchUploads() {
 		if (!data.user) return;
-
 		loading = true;
 		error = null;
 		try {
@@ -155,20 +125,16 @@
 				`sort_field=${encodeURIComponent(sortField)}`,
 				`sort_order=${encodeURIComponent(sortOrder)}`
 			];
-
-			// Add folder filter - empty string means root level only
 			if (currentFolderId === null) {
 				queryParts.push('folder_id=');
 			} else {
 				queryParts.push(`folder_id=${encodeURIComponent(currentFolderId)}`);
 			}
-
 			const response = await fetch(`/api/uploads?${queryParts.join('&')}`);
 			if (!response.ok) {
 				const errorData = await response.json();
 				throw new Error(errorData.error?.message || 'Failed to fetch uploads');
 			}
-
 			const result = await response.json();
 			uploads = result.data || [];
 			total = result.pagination?.total || 0;
@@ -180,20 +146,17 @@
 		}
 	}
 
-	// Refresh data after successful operations
 	function refreshData() {
 		fetchFolders();
 		fetchUploads();
 	}
 
-	// Navigate to folder and update URL
 	function navigateToFolder(folderId: string | null) {
 		currentFolderId = folderId;
 		currentPage = 1;
 		updateUrlPath(folderId);
 	}
 
-	// Update URL with current folder path (same page, just updating query param)
 	function updateUrlPath(folderId: string | null) {
 		const url = new URL($page.url);
 		if (folderId) {
@@ -205,32 +168,27 @@
 		replaceState(`${url.pathname}${url.search}`, {});
 	}
 
-	// Open delete dialogs
-	function openDeleteUploadDialog(upload: UploadWithCompositeId) {
+	// Action handlers
+	function handleDeleteUpload(upload: UploadWithCompositeId) {
 		uploadToDelete = upload;
 		deleteUploadDialogOpen = true;
 	}
 
-	function openDeleteFolderDialog(folder: Folder) {
+	function handleDeleteFolder(folder: Folder) {
 		folderToDelete = folder;
 		deleteFolderDialogOpen = true;
 	}
 
-	// Download file
-	async function downloadFile(upload: UploadWithCompositeId) {
+	async function handleDownload(upload: UploadWithCompositeId) {
 		if (!upload.did || !upload.local_id) {
 			toast.error('Download not available for this file');
 			return;
 		}
 		try {
 			const response = await fetch(getUploadApiUrl(upload));
-			if (!response.ok) {
-				throw new Error('Failed to get download URL');
-			}
-
+			if (!response.ok) throw new Error('Failed to get download URL');
 			const result = await response.json();
 			const downloadUrl = result.data?.downloadUrl;
-
 			if (downloadUrl) {
 				window.open(downloadUrl, '_blank');
 			} else {
@@ -241,34 +199,24 @@
 		}
 	}
 
-	// Copy link to clipboard - fetches current public status before deciding
-	async function copyLink(upload: UploadWithCompositeId) {
-		if (!upload.url) {
-			toast.error('URL not available');
-			return;
-		}
-		if (!upload.did || !upload.local_id) {
+	async function handleCopyLink(upload: UploadWithCompositeId) {
+		if (!upload.url || !upload.did || !upload.local_id) {
 			toast.error('Link not available for this file');
 			return;
 		}
 		try {
 			const response = await fetch(getUploadApiUrl(upload));
-			if (!response.ok) {
-				throw new Error('Failed to get upload info');
-			}
-
+			if (!response.ok) throw new Error('Failed to get upload info');
 			const result = await response.json();
 			const isPublic = result.data?.isPublic ?? upload.is_public;
 			const downloadUrl = result.data?.downloadUrl;
-
 			if (isPublic && downloadUrl) {
 				await navigator.clipboard.writeText(downloadUrl);
 				toast.success('Link copied to clipboard');
 				return;
 			}
-
-			// For private files, open share dialog
-			openShareDialog(upload);
+			uploadToShare = upload;
+			shareDialogOpen = true;
 		} catch {
 			if (upload.is_public) {
 				try {
@@ -278,99 +226,48 @@
 					toast.error('Failed to copy link');
 				}
 			} else {
-				openShareDialog(upload);
+				uploadToShare = upload;
+				shareDialogOpen = true;
 			}
 		}
 	}
 
-	// Open dialogs
-	function openMoveDialog(upload: UploadWithCompositeId) {
-		uploadToMove = upload;
-		moveDialogOpen = true;
-	}
-
-	function openRenameDialog(upload: UploadWithCompositeId) {
+	function handleRename(upload: UploadWithCompositeId) {
 		uploadToRename = upload;
 		renameDialogOpen = true;
 	}
 
-	function openShareDialog(upload: UploadWithCompositeId) {
-		uploadToShare = upload;
-		shareDialogOpen = true;
+	function handleMove(upload: UploadWithCompositeId) {
+		uploadToMove = upload;
+		moveDialogOpen = true;
 	}
 
-	// Callbacks that adapt DisplayItem events to Upload-specific logic
-	function handleTablePreview(item: DisplayItem) {
-		if (item.kind !== 'file') return;
-		const index = fileDisplayItems.findIndex((di) => di.id === item.id);
-		if (index >= 0) {
-			mediaPreviewIndex = index;
-			mediaPreviewOpen = true;
-		}
-	}
-
-	function handleTableDownload(item: DisplayItem) {
-		if (item.kind === 'file') downloadFile(item.data);
-	}
-
-	function handleTableCopyLink(item: DisplayItem) {
-		if (item.kind === 'file') copyLink(item.data);
-	}
-
-	function handleTableRename(item: DisplayItem) {
-		if (item.kind === 'file') openRenameDialog(item.data);
-	}
-
-	function handleTableMove(item: DisplayItem) {
-		if (item.kind === 'file') openMoveDialog(item.data);
-	}
-
-	function handleTableDelete(item: DisplayItem) {
-		if (item.kind === 'file') openDeleteUploadDialog(item.data);
-	}
-
-	function handleGridFolderClick(folder: Folder) {
-		navigateToFolder(typeof folder.id === 'string' ? folder.id : folder.id.toString());
-	}
-
-	function handleGridFolderDelete(folder: Folder) {
-		openDeleteFolderDialog(folder);
-	}
-
-	function handleGridItemClick(index: number) {
+	function handlePreview(_item: DisplayItem, index: number) {
 		mediaPreviewIndex = index;
 		mediaPreviewOpen = true;
 	}
 
-	// Track previous sort values
+	// Track previous sort values for reset-on-change
 	let prevSortField = $state<string | undefined>(undefined);
 	let prevSortOrder = $state<string | undefined>(undefined);
 
 	$effect(() => {
-		if (prevSortField === undefined) {
-			prevSortField = sortField;
-		}
-		if (prevSortOrder === undefined) {
-			prevSortOrder = sortOrder;
-		}
+		if (prevSortField === undefined) prevSortField = sortField;
+		if (prevSortOrder === undefined) prevSortOrder = sortOrder;
 	});
 
-	// Watch for changes and refetch
 	$effect(() => {
 		if (!data.user) return;
-
 		const currentSortField = sortField;
 		const currentSortOrder = sortOrder;
 		const currentPageValue = currentPage;
 		const currentFolder = currentFolderId;
 
-		// Reset to first page when sorting changes
 		if (prevSortField !== undefined && prevSortOrder !== undefined) {
 			if (prevSortField !== currentSortField || prevSortOrder !== currentSortOrder) {
 				currentPage = 1;
 			}
 		}
-
 		prevSortField = currentSortField;
 		prevSortOrder = currentSortOrder;
 
@@ -382,30 +279,6 @@
 		fetchFolders();
 		fetchUploads();
 	});
-
-	// Calculate total pages
-	const totalPages = $derived(Math.ceil(total / limit));
-
-	// Sort field labels
-	function getSortFieldLabel(field: string): string {
-		if (field === 'created_at') return 'Created';
-		if (field === 'updated_at') return 'Updated';
-		if (field === 'filename') return 'Filename';
-		if (field === 'size') return 'Size';
-		return field;
-	}
-
-	function getSortOrderLabel(order: string): string {
-		return order === 'asc' ? 'Ascending' : 'Descending';
-	}
-
-	// Check if folder is a public folder
-	function isPublicFolder(folder: Folder): boolean {
-		return folder.name.toLowerCase() === 'public';
-	}
-
-	// Check if currently in a public folder hierarchy
-	const isInPublicFolder = $derived(breadcrumbs.some((b) => b.name.toLowerCase() === 'public'));
 </script>
 
 <svelte:head>
@@ -414,7 +287,6 @@
 
 {#if data.user}
 	<div class="space-y-6 p-4 sm:p-6 lg:p-8">
-		<!-- Page Header -->
 		<div class="flex items-start justify-between gap-4">
 			<div class="space-y-1">
 				<h1 class="text-3xl font-bold tracking-tight">Uploads</h1>
@@ -422,91 +294,28 @@
 			</div>
 		</div>
 
-		<!-- Breadcrumb Navigation -->
-		<nav class="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto text-sm">
-			<Button
-				variant="ghost"
-				size="sm"
-				class="h-8 gap-1 px-2"
-				onclick={() => navigateToFolder(null)}
-			>
-				<Home class="h-4 w-4" />
-				<span>Root</span>
-			</Button>
-			{#each breadcrumbs as crumb (crumb.id)}
-				<ChevronRight class="h-4 w-4 text-muted-foreground" />
-				<Button
-					variant="ghost"
-					size="sm"
-					class="h-8 px-2"
-					onclick={() => navigateToFolder(crumb.id)}
-				>
-					{crumb.name}
-				</Button>
-			{/each}
-		</nav>
-
-		<!-- Controls Row -->
-		<div class="flex flex-wrap items-center justify-between gap-4">
-			<div class="flex flex-wrap items-center gap-2">
-				<Select.Root type="single" bind:value={sortField}>
-					<Select.Trigger class="w-[140px]">
-						{getSortFieldLabel(sortField)}
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Item value="created_at">Created</Select.Item>
-						<Select.Item value="updated_at">Updated</Select.Item>
-						<Select.Item value="filename">Filename</Select.Item>
-						<Select.Item value="size">Size</Select.Item>
-					</Select.Content>
-				</Select.Root>
-
-				<Select.Root type="single" bind:value={sortOrder}>
-					<Select.Trigger class="w-[140px]">
-						{getSortOrderLabel(sortOrder)}
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Item value="desc">Descending</Select.Item>
-						<Select.Item value="asc">Ascending</Select.Item>
-					</Select.Content>
-				</Select.Root>
-
-				{#if totalPages > 1}
-					<Pagination.Root bind:page={currentPage} count={total} perPage={limit} siblingCount={1}>
-						{#snippet children({ pages, currentPage: activePage })}
-							<Pagination.Content>
-								<Pagination.Item>
-									<Pagination.PrevButton />
-								</Pagination.Item>
-								{#each pages as page (page.key)}
-									{#if page.type === 'ellipsis'}
-										<Pagination.Item>
-											<Pagination.Ellipsis />
-										</Pagination.Item>
-									{:else}
-										<Pagination.Item>
-											<Pagination.Link {page} isActive={activePage === page.value}>
-												{page.value}
-											</Pagination.Link>
-										</Pagination.Item>
-									{/if}
-								{/each}
-								<Pagination.Item>
-									<Pagination.NextButton />
-								</Pagination.Item>
-							</Pagination.Content>
-						{/snippet}
-					</Pagination.Root>
-				{/if}
-			</div>
-			<div class="flex flex-wrap items-center gap-2">
-				<ViewModeToggle
-					bind:mode={viewMode}
-					availableModes={['list', 'gallery', 'masonry', 'carousel', 'cards']}
-				/>
-				<span class="text-sm text-muted-foreground">
-					{total} file{total !== 1 ? 's' : ''} total
-				</span>
+		<FileBrowser
+			{folders}
+			{uploads}
+			{breadcrumbs}
+			{loading}
+			{error}
+			{total}
+			bind:viewMode
+			bind:currentPage
+			bind:limit
+			bind:sortField
+			bind:sortOrder
+			onNavigateFolder={navigateToFolder}
+			onDeleteUpload={handleDeleteUpload}
+			onDeleteFolder={handleDeleteFolder}
+			onPreview={handlePreview}
+			onDownload={handleDownload}
+			onCopyLink={handleCopyLink}
+			onRename={handleRename}
+			onMove={handleMove}
+		>
+			{#snippet actions()}
 				<Button variant="outline" onclick={() => (createFolderDialogOpen = true)}>
 					<FolderPlus class="mr-2 h-4 w-4" />
 					New Folder
@@ -515,138 +324,50 @@
 					<Plus class="mr-2 h-4 w-4" />
 					Upload File
 				</Button>
-			</div>
-		</div>
-
-		<!-- Content Area -->
-		{#if loading}
-			<Card.Root>
-				<Card.Content class="py-12">
-					<div class="flex flex-col items-center gap-2">
-						<Skeleton class="h-8 w-48" />
-						<Skeleton class="h-4 w-32" />
-					</div>
-				</Card.Content>
-			</Card.Root>
-		{:else if error}
-			<Card.Root>
-				<Card.Content class="py-6">
-					<p class="text-center text-destructive">{error}</p>
-				</Card.Content>
-			</Card.Root>
-		{:else if uploads.length === 0 && folders.length === 0}
-			<Card.Root>
-				<Card.Content class="py-12">
-					<div class="space-y-2 text-center">
-						<File class="mx-auto h-12 w-12 text-muted-foreground" />
-						<h3 class="text-lg font-semibold">No files or folders</h3>
-						<p class="text-sm text-muted-foreground">
-							{currentFolderId ? 'This folder is empty' : 'Your uploaded files will appear here'}
-						</p>
-					</div>
-				</Card.Content>
-			</Card.Root>
-		{:else if viewMode === 'list'}
-			<!-- List/Table view -->
-			<FileTable
-				items={displayItems}
-				onPreview={handleTablePreview}
-				onDownload={handleTableDownload}
-				onCopyLink={handleTableCopyLink}
-				onRename={handleTableRename}
-				onMove={handleTableMove}
-				onDelete={handleTableDelete}
-				onFolderClick={handleGridFolderClick}
-				onFolderDelete={handleGridFolderDelete}
-			/>
-		{:else if viewMode === 'carousel'}
-			<!-- Carousel view: folders shown above as cards, then carousel for files -->
-			{#if folders.length > 0}
-				<div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-					{#each folders as folder (folder.id.toString())}
-						<FolderCard
-							{folder}
-							isPublic={isPublicFolder(folder)}
-							onclick={() => handleGridFolderClick(folder)}
-							onDelete={handleGridFolderDelete}
-						/>
-					{/each}
-				</div>
-			{/if}
-			<FileCarousel items={fileDisplayItems} onItemClick={handleGridItemClick} />
-		{:else if viewMode === 'cards'}
-			{#if folders.length > 0}
-				<div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-					{#each folders as folder (folder.id.toString())}
-						<FolderCard
-							{folder}
-							isPublic={isPublicFolder(folder)}
-							onclick={() => handleGridFolderClick(folder)}
-							onDelete={handleGridFolderDelete}
-						/>
-					{/each}
-				</div>
-			{/if}
-			<MediaCardGrid items={fileDisplayItems} onItemClick={handleGridItemClick} />
-		{:else}
-			<!-- Gallery or Masonry view -->
-			<FileGrid
-				items={displayItems}
-				mode={viewMode === 'gallery' ? 'gallery' : 'masonry'}
-				onItemClick={handleGridItemClick}
-				onFolderClick={handleGridFolderClick}
-				onFolderDelete={handleGridFolderDelete}
-			/>
-		{/if}
+			{/snippet}
+		</FileBrowser>
 	</div>
 
-	<!-- Dialog Components -->
 	<DeleteUploadDialog
 		upload={uploadToDelete}
 		bind:open={deleteUploadDialogOpen}
 		onSuccess={refreshData}
 	/>
-
 	<DeleteFolderDialog
 		folderId={folderToDelete?.id?.toString() ?? null}
 		folderName={folderToDelete?.name ?? null}
 		bind:open={deleteFolderDialogOpen}
 		onSuccess={refreshData}
 	/>
-
 	<UploadFilesDialog
 		{currentFolderId}
 		{isInPublicFolder}
 		bind:open={uploadDialogOpen}
 		onSuccess={refreshData}
 	/>
-
 	<CreateFolderDialog
 		parentId={currentFolderId}
 		parentName={breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1]?.name : null}
 		bind:open={createFolderDialogOpen}
 		onSuccess={refreshData}
 	/>
-
 	<MoveUploadDialog upload={uploadToMove} bind:open={moveDialogOpen} onSuccess={refreshData} />
-
 	<RenameUploadDialog
 		upload={uploadToRename}
 		bind:open={renameDialogOpen}
 		onSuccess={refreshData}
 	/>
-
 	<ShareUploadDialog upload={uploadToShare} bind:open={shareDialogOpen} />
-
-	<!-- Media preview modal for visual browsing -->
 	<MediaPreviewModal
 		bind:open={mediaPreviewOpen}
 		items={fileDisplayItems}
 		initialIndex={mediaPreviewIndex}
-		onOpenShareDialog={openShareDialog}
+		onOpenShareDialog={(upload) => {
+			uploadToShare = upload;
+			shareDialogOpen = true;
+		}}
 	/>
 {:else}
-	<!-- Not Logged In View -->
 	<div class="flex h-full items-center justify-center p-4 sm:p-6">
 		<Card.Root class="max-w-md">
 			<Card.Header>

--- a/apps/syr/app/src/routes/(private)/uploads/+page.svelte
+++ b/apps/syr/app/src/routes/(private)/uploads/+page.svelte
@@ -200,7 +200,7 @@
 	}
 
 	async function handleCopyLink(upload: UploadWithCompositeId) {
-		if (!upload.url || !upload.did || !upload.local_id) {
+		if (!upload.did || !upload.local_id) {
 			toast.error('Link not available for this file');
 			return;
 		}
@@ -218,7 +218,7 @@
 			uploadToShare = upload;
 			shareDialogOpen = true;
 		} catch {
-			if (upload.is_public) {
+			if (upload.is_public && upload.url) {
 				try {
 					await navigator.clipboard.writeText(upload.url);
 					toast.success('Link copied to clipboard');

--- a/apps/syr/app/src/routes/api/admin/storage/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/storage/+server.ts
@@ -6,6 +6,7 @@ import { userRepository } from '$lib/repositories/user.repository';
 
 const KV_USAGE_TYPE = 'file_store_usage';
 const KV_LIMIT_TYPE = 'file_store_limit_override';
+const MAX_USER_FETCH_LIMIT = 10000;
 
 export const GET: RequestHandler = async ({ locals }) => {
 	if (!locals.user) {
@@ -23,7 +24,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 		getDefaultStorageLimitBytes(),
 		kvService.getByType(KV_USAGE_TYPE),
 		kvService.getByType(KV_LIMIT_TYPE),
-		userRepository.findManyWithSearch({ limit: 10000, offset: 0 })
+		userRepository.findManyWithSearch({ limit: MAX_USER_FETCH_LIMIT, offset: 0 })
 	]);
 
 	// Build usage map: userId string → bytes_used

--- a/apps/syr/app/src/routes/api/admin/storage/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/storage/+server.ts
@@ -1,0 +1,82 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { kvService } from '$lib/services/kv';
+import { getDefaultStorageLimitBytes, getInstanceStorageCapacityBytes } from '$lib/instance-config';
+import { userRepository } from '$lib/repositories/user.repository';
+
+const KV_USAGE_TYPE = 'file_store_usage';
+const KV_LIMIT_TYPE = 'file_store_limit_override';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can view storage overview'
+		});
+	}
+
+	const [capacity, defaultLimit, usageEntries, limitEntries, usersResult] = await Promise.all([
+		getInstanceStorageCapacityBytes(),
+		getDefaultStorageLimitBytes(),
+		kvService.getByType(KV_USAGE_TYPE),
+		kvService.getByType(KV_LIMIT_TYPE),
+		userRepository.findManyWithSearch({ limit: 10000, offset: 0 })
+	]);
+
+	// Build usage map: userId string → bytes_used
+	const usageMap = new Map<string, number>();
+	for (const entry of usageEntries) {
+		const raw = String(entry.id.id);
+		const prefix = `${KV_USAGE_TYPE}:`;
+		const key = raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+		const val = entry.value as { bytes_used?: number };
+		usageMap.set(key, val.bytes_used ?? 0);
+	}
+
+	// Build limit override map: userId string → bytes_limit
+	const limitMap = new Map<string, number>();
+	for (const entry of limitEntries) {
+		const raw = String(entry.id.id);
+		const prefix = `${KV_LIMIT_TYPE}:`;
+		const key = raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+		const val = entry.value as { bytes_limit?: number };
+		if (typeof val.bytes_limit === 'number' && val.bytes_limit > 0) {
+			limitMap.set(key, val.bytes_limit);
+		}
+	}
+
+	// Build per-user breakdown
+	let totalUsed = 0;
+	let totalAllocated = 0;
+	const users = usersResult.data.map((u) => {
+		const uid = u.id.toString();
+		const bytesUsed = usageMap.get(uid) ?? 0;
+		const bytesLimit = limitMap.get(uid) ?? defaultLimit;
+		totalUsed += bytesUsed;
+		totalAllocated += bytesLimit;
+		return {
+			id: uid,
+			username: u.username,
+			bytes_used: bytesUsed,
+			bytes_limit: bytesLimit
+		};
+	});
+
+	// Sort by usage descending
+	users.sort((a, b) => b.bytes_used - a.bytes_used);
+
+	return json({
+		status: 'success',
+		data: {
+			capacity,
+			total_used: totalUsed,
+			total_allocated: totalAllocated,
+			default_limit: defaultLimit,
+			user_count: users.length,
+			users
+		}
+	});
+};

--- a/apps/syr/app/src/routes/api/admin/users/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/+server.ts
@@ -1,0 +1,66 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { userRepository } from '$lib/repositories/user.repository';
+import { profileRepository } from '$lib/repositories/profile.repository';
+
+const QuerySchema = z.object({
+	page: z.coerce.number().int().min(1).default(1),
+	size: z.coerce.number().int().min(1).max(100).default(20),
+	search: z.string().optional()
+});
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	const parsed = QuerySchema.safeParse({
+		page: url.searchParams.get('page') ?? undefined,
+		size: url.searchParams.get('size') ?? undefined,
+		search: url.searchParams.get('search') ?? undefined
+	});
+	if (!parsed.success) {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
+	}
+
+	const { page, size, search } = parsed.data;
+	const offset = (page - 1) * size;
+
+	const { data: users, total } = await userRepository.findManyWithSearch({
+		limit: size,
+		offset,
+		search,
+		sort: { field: 'created_at', order: 'desc' }
+	});
+
+	// Batch-fetch profiles
+	const userIds = users.map((u) => u.id);
+	const profiles = await profileRepository.findByUserIds(userIds);
+	const profileMap = new Map(profiles.map((p) => [p.user_id.toString(), p]));
+
+	const data = users.map((u) => {
+		const profile = profileMap.get(u.id.toString());
+		return {
+			id: u.id.toString(),
+			username: u.username,
+			did: u.did ?? null,
+			role: u.role,
+			created_at: u.created_at.toISOString(),
+			display_name: profile?.display_name ?? u.username,
+			avatar_url: profile?.avatar_url ?? null
+		};
+	});
+
+	return json({
+		status: 'success',
+		data,
+		pagination: { limit: size, offset, total, has_more: offset + size < total }
+	});
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/+server.ts
@@ -1,0 +1,76 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { profileRepository } from '$lib/repositories/profile.repository';
+import { deleteAccount } from '$lib/services/account-deletion.service';
+
+function requireAdmin(locals: App.Locals) {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	requireAdmin(locals);
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	const profile = await profileRepository.findByUserId(userId);
+
+	return json({
+		status: 'success',
+		data: {
+			id: user.id.toString(),
+			username: user.username,
+			did: user.did ?? null,
+			role: user.role,
+			created_at: user.created_at.toISOString(),
+			updated_at: user.updated_at.toISOString(),
+			display_name: profile?.display_name ?? user.username,
+			bio: profile?.bio ?? null,
+			avatar_url: profile?.avatar_url ?? null
+		}
+	});
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	requireAdmin(locals);
+
+	// Prevent self-deletion
+	if (params.userId === locals.user!.id) {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Cannot delete your own account' });
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	await deleteAccount(userId);
+
+	return json({ status: 'success', message: 'User account deleted' });
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/folders/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/folders/+server.ts
@@ -1,0 +1,47 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { folderController } from '$lib/controllers/folder.controller';
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	const parentId = url.searchParams.get('parent_id') || null;
+
+	const folders = await folderController.getFolders(userId, parentId);
+	const breadcrumbs = parentId ? await folderController.getBreadcrumbs(parentId) : [];
+
+	return json({
+		status: 'success',
+		data: {
+			folders: folders.map((f) => ({
+				id: f.id.toString(),
+				name: f.name,
+				parent_id: f.parent_id?.toString() ?? null,
+				created_at: f.created_at.toISOString()
+			})),
+			breadcrumbs
+		}
+	});
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/posts/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/posts/+server.ts
@@ -1,7 +1,7 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
-import { stringToRecordId } from '@syr-is/types';
+import { stringToRecordId, extractDid, extractLocalId } from '@syr-is/types';
 import { userRepository } from '$lib/repositories/user.repository';
 import { postController } from '$lib/controllers/post.controller';
 
@@ -50,16 +50,26 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 		sort: { field: 'created_at', order: 'desc' }
 	});
 
-	const data = posts.map((p) => ({
-		id: p.id.toString(),
-		did: p.did ?? null,
-		local_id: p.local_id ?? null,
-		type: p.type,
-		title: p.title ?? null,
-		visibility: p.visibility,
-		status: p.status,
-		created_at: p.created_at.toISOString()
-	}));
+	const data = posts.map((p) => {
+		let did: string | null = null;
+		let local_id: string | null = null;
+		try {
+			did = extractDid(p.id);
+			local_id = extractLocalId(p.id);
+		} catch {
+			// non-composite ID
+		}
+		return {
+			id: p.id.toString(),
+			did,
+			local_id,
+			type: p.type,
+			title: p.title ?? null,
+			visibility: p.visibility,
+			status: p.status,
+			created_at: p.created_at.toISOString()
+		};
+	});
 
 	return json({
 		status: 'success',

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/posts/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/posts/+server.ts
@@ -1,0 +1,69 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { postController } from '$lib/controllers/post.controller';
+
+const QuerySchema = z.object({
+	page: z.coerce.number().int().min(1).default(1),
+	size: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	const parsed = QuerySchema.safeParse({
+		page: url.searchParams.get('page') ?? undefined,
+		size: url.searchParams.get('size') ?? undefined
+	});
+	if (!parsed.success) {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
+	}
+
+	const { page, size } = parsed.data;
+	const offset = (page - 1) * size;
+
+	const { data: posts, total } = await postController.getUserPosts(userId, {
+		limit: size,
+		offset,
+		sort: { field: 'created_at', order: 'desc' }
+	});
+
+	const data = posts.map((p) => ({
+		id: p.id.toString(),
+		did: p.did ?? null,
+		local_id: p.local_id ?? null,
+		type: p.type,
+		title: p.title ?? null,
+		visibility: p.visibility,
+		status: p.status,
+		created_at: p.created_at.toISOString()
+	}));
+
+	return json({
+		status: 'success',
+		data,
+		pagination: { limit: size, offset, total, has_more: offset + size < total }
+	});
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/posts/[did]/[id]/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/posts/[did]/[id]/+server.ts
@@ -1,0 +1,46 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { recordIdFromDidAndLocal } from '@syr-is/types';
+import { postController } from '$lib/controllers/post.controller';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	let postId;
+	try {
+		postId = recordIdFromDidAndLocal('post', params.did, params.id);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid post ID' });
+	}
+
+	const post = await postController.getPost(postId);
+	if (!post) {
+		throw error(404, { code: 'NOT_FOUND', message: 'Post not found' });
+	}
+
+	await postController.deletePost(postId, userId);
+
+	return json({ status: 'success' });
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/storage/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/storage/+server.ts
@@ -1,0 +1,77 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { fileStoreUsageController } from '$lib/controllers/file-store-usage.controller';
+
+function requireAdmin(locals: App.Locals) {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+}
+
+function parseUserId(raw: string) {
+	try {
+		return stringToRecordId.decode(raw);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	requireAdmin(locals);
+	const userId = parseUserId(params.userId);
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	const details = await fileStoreUsageController.getUsageDetails(userId);
+	return json({ status: 'success', data: details });
+};
+
+const PatchBodySchema = z
+	.object({
+		bytes_limit: z.number().int().positive().optional(),
+		reset: z.boolean().optional()
+	})
+	.refine((d) => d.bytes_limit !== undefined || d.reset, {
+		message: 'Provide bytes_limit or set reset to true'
+	});
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	requireAdmin(locals);
+	const userId = parseUserId(params.userId);
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	let body: z.infer<typeof PatchBodySchema>;
+	try {
+		body = PatchBodySchema.parse(await request.json());
+	} catch {
+		throw error(400, {
+			code: 'VALIDATION_ERROR',
+			message: 'Provide bytes_limit or set reset to true'
+		});
+	}
+
+	if (body.reset) {
+		await fileStoreUsageController.clearUserLimit(userId);
+	} else if (body.bytes_limit !== undefined) {
+		await fileStoreUsageController.setUserLimit(userId, body.bytes_limit);
+	}
+
+	const details = await fileStoreUsageController.getUsageDetails(userId);
+	return json({ status: 'success', data: details });
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/storage/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/storage/+server.ts
@@ -25,6 +25,14 @@ function parseUserId(raw: string) {
 	}
 }
 
+function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 B';
+	const k = 1024;
+	const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
 export const GET: RequestHandler = async ({ params, locals }) => {
 	requireAdmin(locals);
 	const userId = parseUserId(params.userId);
@@ -35,16 +43,19 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 	}
 
 	const details = await fileStoreUsageController.getUsageDetails(userId);
-	return json({ status: 'success', data: details });
+	const uploadsEnabled = !(await fileStoreUsageController.isUploadDisabled(userId));
+
+	return json({ status: 'success', data: { ...details, uploads_enabled: uploadsEnabled } });
 };
 
 const PatchBodySchema = z
 	.object({
 		bytes_limit: z.number().int().positive().optional(),
-		reset: z.boolean().optional()
+		reset: z.boolean().optional(),
+		uploads_enabled: z.boolean().optional()
 	})
-	.refine((d) => d.bytes_limit !== undefined || d.reset, {
-		message: 'Provide bytes_limit or set reset to true'
+	.refine((d) => d.bytes_limit !== undefined || d.reset || d.uploads_enabled !== undefined, {
+		message: 'Provide bytes_limit, reset, or uploads_enabled'
 	});
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
@@ -62,16 +73,30 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	} catch {
 		throw error(400, {
 			code: 'VALIDATION_ERROR',
-			message: 'Provide bytes_limit or set reset to true'
+			message: 'Provide bytes_limit, reset, or uploads_enabled'
 		});
 	}
 
 	if (body.reset) {
 		await fileStoreUsageController.clearUserLimit(userId);
 	} else if (body.bytes_limit !== undefined) {
+		// Prevent setting limit below current usage
+		const currentUsage = await fileStoreUsageController.getUsage(userId);
+		if (body.bytes_limit < currentUsage) {
+			throw error(400, {
+				code: 'VALIDATION_ERROR',
+				message: `Cannot set limit below current usage (${formatBytes(currentUsage)})`
+			});
+		}
 		await fileStoreUsageController.setUserLimit(userId, body.bytes_limit);
 	}
 
+	if (body.uploads_enabled !== undefined) {
+		await fileStoreUsageController.setUploadDisabled(userId, !body.uploads_enabled);
+	}
+
 	const details = await fileStoreUsageController.getUsageDetails(userId);
-	return json({ status: 'success', data: details });
+	const uploadsEnabled = !(await fileStoreUsageController.isUploadDisabled(userId));
+
+	return json({ status: 'success', data: { ...details, uploads_enabled: uploadsEnabled } });
 };

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/+server.ts
@@ -1,0 +1,69 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { uploadRepository } from '$lib/repositories/upload.repository';
+
+const QuerySchema = z.object({
+	page: z.coerce.number().int().min(1).default(1),
+	size: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	const parsed = QuerySchema.safeParse({
+		page: url.searchParams.get('page') ?? undefined,
+		size: url.searchParams.get('size') ?? undefined
+	});
+	if (!parsed.success) {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
+	}
+
+	const { page, size } = parsed.data;
+	const offset = (page - 1) * size;
+
+	const { data: uploads, total } = await uploadRepository.findMany({
+		limit: size,
+		offset,
+		sort: { field: 'created_at', order: 'desc' },
+		filters: { owner_id: userId }
+	});
+
+	const data = uploads.map((u) => ({
+		id: u.id.toString(),
+		filename: u.filename,
+		mime_type: u.mime_type,
+		size: u.size,
+		status: u.status,
+		is_public: u.is_public,
+		created_at: u.created_at.toISOString()
+	}));
+
+	return json({
+		status: 'success',
+		data,
+		pagination: { limit: size, offset, total, has_more: offset + size < total }
+	});
+};

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/+server.ts
@@ -1,13 +1,16 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
-import { stringToRecordId } from '@syr-is/types';
+import { stringToRecordId, extractDid, extractLocalId } from '@syr-is/types';
 import { userRepository } from '$lib/repositories/user.repository';
 import { uploadRepository } from '$lib/repositories/upload.repository';
 
 const QuerySchema = z.object({
 	page: z.coerce.number().int().min(1).default(1),
-	size: z.coerce.number().int().min(1).max(100).default(20)
+	size: z.coerce.number().int().min(1).max(100).default(20),
+	sort_field: z.enum(['created_at', 'updated_at', 'filename', 'size']).default('created_at'),
+	sort_order: z.enum(['asc', 'desc']).default('desc'),
+	folder_id: z.string().optional()
 });
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
@@ -35,31 +38,66 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 
 	const parsed = QuerySchema.safeParse({
 		page: url.searchParams.get('page') ?? undefined,
-		size: url.searchParams.get('size') ?? undefined
+		size: url.searchParams.get('size') ?? undefined,
+		sort_field: url.searchParams.get('sort_field') ?? undefined,
+		sort_order: url.searchParams.get('sort_order') ?? undefined,
+		folder_id: url.searchParams.get('folder_id') ?? undefined
 	});
 	if (!parsed.success) {
 		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
 	}
 
-	const { page, size } = parsed.data;
+	const { page, size, sort_field, sort_order, folder_id } = parsed.data;
 	const offset = (page - 1) * size;
+
+	// Build filters
+	const filters: Record<string, unknown> = { owner_id: userId };
+
+	// folder_id semantics: absent = all uploads, empty string = root only, value = specific folder
+	const rawFolderId = url.searchParams.get('folder_id');
+	if (rawFolderId !== null) {
+		if (rawFolderId === '') {
+			filters.folder_id = null; // root level only
+		} else if (folder_id) {
+			try {
+				filters.folder_id = stringToRecordId.decode(folder_id);
+			} catch {
+				throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid folder ID' });
+			}
+		}
+	}
 
 	const { data: uploads, total } = await uploadRepository.findMany({
 		limit: size,
 		offset,
-		sort: { field: 'created_at', order: 'desc' },
-		filters: { owner_id: userId }
+		sort: { field: sort_field, order: sort_order },
+		filters
 	});
 
-	const data = uploads.map((u) => ({
-		id: u.id.toString(),
-		filename: u.filename,
-		mime_type: u.mime_type,
-		size: u.size,
-		status: u.status,
-		is_public: u.is_public,
-		created_at: u.created_at.toISOString()
-	}));
+	const data = uploads.map((u) => {
+		let did: string | null = null;
+		let local_id: string | null = null;
+		try {
+			did = extractDid(u.id);
+			local_id = extractLocalId(u.id);
+		} catch {
+			// non-composite ID
+		}
+		return {
+			id: u.id.toString(),
+			did,
+			local_id,
+			filename: u.filename,
+			mime_type: u.mime_type,
+			size: u.size,
+			status: u.status,
+			is_public: u.is_public,
+			key: u.key ?? null,
+			folder_id: u.folder_id?.toString() ?? null,
+			url: u.url ?? null,
+			created_at: u.created_at.toISOString()
+		};
+	});
 
 	return json({
 		status: 'success',

--- a/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/[did]/[id]/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/users/[userId]/uploads/[did]/[id]/+server.ts
@@ -1,0 +1,47 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { recordIdFromDidAndLocal, stringToRecordId } from '@syr-is/types';
+import { userRepository } from '$lib/repositories/user.repository';
+import { uploadController } from '$lib/controllers/upload.controller';
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) {
+		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
+	}
+	if (locals.user.role !== 'ADMIN') {
+		throw error(403, {
+			code: 'FORBIDDEN',
+			message: 'Only instance administrators can manage users'
+		});
+	}
+
+	let userId;
+	try {
+		userId = stringToRecordId.decode(params.userId);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid user ID' });
+	}
+
+	const user = await userRepository.findById(userId);
+	if (!user) {
+		throw error(404, { code: 'NOT_FOUND', message: 'User not found' });
+	}
+
+	let uploadId;
+	try {
+		uploadId = recordIdFromDidAndLocal('upload', params.did, params.id);
+	} catch {
+		throw error(400, { code: 'VALIDATION_ERROR', message: 'Invalid upload ID' });
+	}
+
+	try {
+		await uploadController.deleteUpload(uploadId);
+	} catch (err) {
+		if (err instanceof Error && err.message === 'Upload not found') {
+			throw error(404, { code: 'NOT_FOUND', message: 'Upload not found' });
+		}
+		throw err;
+	}
+
+	return json({ status: 'success' });
+};

--- a/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
+++ b/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
@@ -67,6 +67,12 @@ function validateRegistrationMode(val: string): string {
 	return result.data;
 }
 
+const ADMIN_ONLY_KEYS: readonly string[] = [
+	KEY_REGISTRATION_MODE,
+	KEY_DEFAULT_STORAGE_LIMIT_GB,
+	KEY_INSTANCE_STORAGE_CAPACITY_GB
+];
+
 export const GET: RequestHandler = async ({ params, locals }) => {
 	if (!locals.user) {
 		throw error(401, { code: 'UNAUTHORIZED', message: 'Authentication required' });
@@ -74,6 +80,9 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 	const key = params.key;
 	if (!isAllowedKey(key)) {
 		throw error(404, { code: 'NOT_FOUND', message: 'Unknown instance config key' });
+	}
+	if (ADMIN_ONLY_KEYS.includes(key) && locals.user.role !== 'ADMIN') {
+		throw error(403, { code: 'FORBIDDEN', message: 'Admin access required' });
 	}
 	const value = await kvService.get<string>(INSTANCE_CONFIG_TYPE, key);
 	return json({ value: value ?? null });

--- a/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
+++ b/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
@@ -8,6 +8,7 @@ import {
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	KEY_REGISTRATION_MODE,
 	KEY_DEFAULT_STORAGE_LIMIT_GB,
+	KEY_INSTANCE_STORAGE_CAPACITY_GB,
 	DEFAULT_PATH
 } from '$lib/instance-config';
 import { RegistrationModeSchema } from '@syr-is/types';
@@ -16,7 +17,8 @@ const INSTANCE_CONFIG_KEYS = [
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	KEY_REGISTRATION_MODE,
-	KEY_DEFAULT_STORAGE_LIMIT_GB
+	KEY_DEFAULT_STORAGE_LIMIT_GB,
+	KEY_INSTANCE_STORAGE_CAPACITY_GB
 ] as const;
 type AllowedKey = (typeof INSTANCE_CONFIG_KEYS)[number];
 
@@ -107,7 +109,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 			value = validateCooldownDaysValue(body.value);
 		} else if (key === KEY_REGISTRATION_MODE) {
 			value = validateRegistrationMode(body.value);
-		} else if (key === KEY_DEFAULT_STORAGE_LIMIT_GB) {
+		} else if (key === KEY_DEFAULT_STORAGE_LIMIT_GB || key === KEY_INSTANCE_STORAGE_CAPACITY_GB) {
 			value = validateStorageLimitGb(body.value);
 		} else {
 			value = validatePathValue(body.value);

--- a/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
+++ b/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
@@ -7,6 +7,7 @@ import {
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
 	KEY_REGISTRATION_MODE,
+	KEY_DEFAULT_STORAGE_LIMIT_GB,
 	DEFAULT_PATH
 } from '$lib/instance-config';
 import { RegistrationModeSchema } from '@syr-is/types';
@@ -14,7 +15,8 @@ import { RegistrationModeSchema } from '@syr-is/types';
 const INSTANCE_CONFIG_KEYS = [
 	KEY_PROFILE_SYNC_ASSET_PATH,
 	KEY_USERNAME_CHANGE_COOLDOWN_DAYS,
-	KEY_REGISTRATION_MODE
+	KEY_REGISTRATION_MODE,
+	KEY_DEFAULT_STORAGE_LIMIT_GB
 ] as const;
 type AllowedKey = (typeof INSTANCE_CONFIG_KEYS)[number];
 
@@ -41,6 +43,15 @@ function validateCooldownDaysValue(val: string): string {
 	const n = parseInt(val.trim(), 10);
 	if (isNaN(n) || n < 1 || n > 365) {
 		throw new Error('Value must be an integer between 1 and 365');
+	}
+	return String(n);
+}
+
+/** Validate storage limit in GB: positive number */
+function validateStorageLimitGb(val: string): string {
+	const n = parseFloat(val.trim());
+	if (isNaN(n) || n <= 0) {
+		throw new Error('Value must be a positive number (in GB)');
 	}
 	return String(n);
 }
@@ -96,6 +107,8 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 			value = validateCooldownDaysValue(body.value);
 		} else if (key === KEY_REGISTRATION_MODE) {
 			value = validateRegistrationMode(body.value);
+		} else if (key === KEY_DEFAULT_STORAGE_LIMIT_GB) {
+			value = validateStorageLimitGb(body.value);
 		} else {
 			value = validatePathValue(body.value);
 		}

--- a/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
+++ b/apps/syr/app/src/routes/api/instance-config/[key]/+server.ts
@@ -52,8 +52,8 @@ function validateCooldownDaysValue(val: string): string {
 /** Validate storage limit in GB: positive number */
 function validateStorageLimitGb(val: string): string {
 	const n = parseFloat(val.trim());
-	if (isNaN(n) || n <= 0) {
-		throw new Error('Value must be a positive number (in GB)');
+	if (!Number.isFinite(n) || n <= 0) {
+		throw new Error('Value must be a finite positive number (in GB)');
 	}
 	return String(n);
 }


### PR DESCRIPTION
## Description

Add admin-only user management at /settings/users with:
- Paginated user list with search by username/DID
- User detail page with info, storage, posts, and uploads
- Per-user storage limit overrides (KV-backed, falls back to 5GB default)
- Admin CRUD API for user accounts, posts, uploads, and storage
- Type-to-confirm user deletion dialog using existing cascade service
- Post and upload deletion with confirmation dialogs

## Type of Change

- [x] New feature

## Related Issues

Closes #37 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin "Users" settings: searchable, debounced, paginated list with Manage links; per-user detail page with profile, posts, uploads, storage and mutation actions.
  * Unified File Browser: folder browsing, multiple view modes, pagination, sorting, and file actions (preview, download, copy link, rename, move, delete).
  * Instance storage controls: instance capacity/default limit UI, editable per-user limits, and storage overview with per-user allocations.

* **UI**
  * Destructive confirmation dialogs for deleting users, posts, and uploads with confirmation gating, spinners, and disabled actions during operations.
  * Settings navigation: added "Users" entry and improved active-item highlighting for nested routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->