### PR TITLE
chore(uploads): runes cleanup + drop dead imports + replace lazy anys

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,17 +1,17 @@
-name: 'Setup pnpm'
-description: 'Install Node.js, pnpm, cache store, and run pnpm install'
+name: "Setup pnpm"
+description: "Install Node.js, pnpm, cache store, and run pnpm install"
 inputs:
   node-version:
-    description: 'Node.js version'
+    description: "Node.js version"
     required: false
-    default: '20'
+    default: "20"
   pnpm-version:
-    description: 'pnpm version'
+    description: "pnpm version"
     required: false
-    default: '10.29.3'
+    default: "10.29.3"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/setup-node@v4
       with:
@@ -29,3 +29,16 @@ runs:
         restore-keys: ${{ runner.os }}-pnpm-store-
     - run: pnpm install --frozen-lockfile
       shell: bash
+    # @syr-is/crypto's build invokes `wasm-pack build`. Turbo pulls
+    # that build into the dependency graph of nearly every TS task
+    # (lint, check, build, test all transitively rely on it), so the
+    # runner needs the wasm toolchain. Without it, any branch that
+    # misses the remote turbo cache fails with
+    # `sh: 1: wasm-pack: not found`. Baking it into the shared
+    # composite keeps individual workflow files thin.
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+    - uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: "latest"

--- a/apps/syr/app/src/lib/components/fragments/upload-files-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/upload-files-dialog.svelte
@@ -57,12 +57,7 @@
 		</Dialog.Header>
 		<div class="py-4">
 			<div class="flex flex-col gap-4">
-				<Input
-					type="file"
-					multiple
-					onchange={handleFileSelect}
-					class="cursor-pointer"
-				/>
+				<Input type="file" multiple onchange={handleFileSelect} class="cursor-pointer" />
 				<p class="text-xs text-muted-foreground">
 					You can select multiple files. Uploads continue in the background.
 				</p>

--- a/apps/syr/app/src/lib/components/fragments/upload-instance-media-dialog.svelte
+++ b/apps/syr/app/src/lib/components/fragments/upload-instance-media-dialog.svelte
@@ -48,12 +48,7 @@
 		</Dialog.Header>
 		<div class="py-4">
 			<div class="flex flex-col gap-4">
-				<Input
-					type="file"
-					multiple
-					onchange={handleFileSelect}
-					class="cursor-pointer"
-				/>
+				<Input type="file" multiple onchange={handleFileSelect} class="cursor-pointer" />
 				<p class="text-xs text-muted-foreground">
 					You can select multiple files. Uploads continue in the background.
 				</p>

--- a/apps/syr/app/src/lib/components/fragments/upload-progress-toast.svelte
+++ b/apps/syr/app/src/lib/components/fragments/upload-progress-toast.svelte
@@ -119,13 +119,21 @@
 			{#each queue.list as upload (upload.id)}
 				{@const icon = statusIcon(upload.status)}
 				{@const label = statusLabel(upload.status)}
-				<div class="flex items-center gap-2 px-3 py-1.5 {upload.status === 'failed' ? 'bg-destructive/5' : ''}">
+				<div
+					class="flex items-center gap-2 px-3 py-1.5 {upload.status === 'failed'
+						? 'bg-destructive/5'
+						: ''}"
+				>
 					<!-- Status indicator -->
 					<div class="flex h-4 w-4 shrink-0 items-center justify-center">
 						{#if icon === 'spinner'}
 							<Loader2 class="h-3.5 w-3.5 animate-spin text-muted-foreground" />
 						{:else if icon === 'progress'}
-							<div class="h-3.5 w-3.5 rounded-full border-2 border-primary" style="background: conic-gradient(var(--color-primary) {upload.progress * 360}deg, transparent 0)"></div>
+							<div
+								class="h-3.5 w-3.5 rounded-full border-2 border-primary"
+								style="background: conic-gradient(var(--color-primary) {upload.progress *
+									360}deg, transparent 0)"
+							></div>
 						{:else if icon === 'check'}
 							<Check class="h-3.5 w-3.5 text-green-500" />
 						{:else if icon === 'error'}
@@ -139,7 +147,11 @@
 
 					<!-- Filename + progress -->
 					<div class="flex min-w-0 flex-1 flex-col gap-0.5">
-						<span class="truncate text-xs {upload.status === 'completed' ? 'text-muted-foreground' : 'text-foreground'}">
+						<span
+							class="truncate text-xs {upload.status === 'completed'
+								? 'text-muted-foreground'
+								: 'text-foreground'}"
+						>
 							{upload.filename}
 						</span>
 						{#if upload.status === 'uploading'}
@@ -157,7 +169,9 @@
 					<!-- Percent or action -->
 					<div class="flex shrink-0 items-center">
 						{#if upload.status === 'uploading'}
-							<span class="mr-1 text-[10px] text-muted-foreground">{Math.round(upload.progress * 100)}%</span>
+							<span class="mr-1 text-[10px] text-muted-foreground"
+								>{Math.round(upload.progress * 100)}%</span
+							>
 						{/if}
 						{#if isActive(upload)}
 							<button

--- a/apps/syr/app/src/lib/controllers/upload.controller.ts
+++ b/apps/syr/app/src/lib/controllers/upload.controller.ts
@@ -317,7 +317,8 @@ export class UploadController {
 				);
 				return result;
 			} catch (err) {
-				const status = (err as any)?.$metadata?.httpStatusCode;
+				const status = (err as { $metadata?: { httpStatusCode?: number } })?.$metadata
+					?.httpStatusCode;
 				if (status === 404 && attempt < maxAttempts - 1) {
 					await new Promise((r) => setTimeout(r, delayMs));
 					continue;
@@ -334,7 +335,7 @@ export class UploadController {
 	 */
 	private async verifyHeadObject(
 		headResult: import('@aws-sdk/client-s3').HeadObjectCommandOutput,
-		upload: any,
+		upload: Upload,
 		uploadId: string | RecordId
 	) {
 		const actualSize = headResult.ContentLength ?? 0;
@@ -348,7 +349,9 @@ export class UploadController {
 		if (upload.sha256 && headResult.ChecksumSHA256) {
 			const expectedBase64 = hexToBase64(upload.sha256);
 			if (headResult.ChecksumSHA256 !== expectedBase64) {
-				await s3Service.client.send(new DeleteObjectCommand({ Bucket: s3.bucket, Key: upload.key }));
+				await s3Service.client.send(
+					new DeleteObjectCommand({ Bucket: s3.bucket, Key: upload.key })
+				);
 				await uploadRepository.delete(uploadId);
 				throw new Error('File checksum mismatch. Upload rejected.');
 			}
@@ -359,7 +362,7 @@ export class UploadController {
 	 * Background finalization: retries HeadObject with exponential backoff
 	 * up to 5 minutes, then completes the upload when the file appears.
 	 */
-	private backgroundFinalize(uploadId: string | RecordId, upload: any) {
+	private backgroundFinalize(uploadId: string | RecordId, upload: Upload) {
 		const MAX_DURATION_MS = 5 * 60 * 1000;
 		const INITIAL_DELAY_MS = 3000;
 		const MAX_DELAY_MS = 15000;
@@ -391,7 +394,8 @@ export class UploadController {
 					console.log('[upload.bg-finalize] Upload completed:', { key: upload.key });
 					return;
 				} catch (err) {
-					const status = (err as any)?.$metadata?.httpStatusCode;
+					const status = (err as { $metadata?: { httpStatusCode?: number } })?.$metadata
+						?.httpStatusCode;
 					if (status === 404) {
 						console.log('[upload.bg-finalize] Still 404, retrying...', {
 							key: upload.key,
@@ -428,7 +432,7 @@ export class UploadController {
 	 * Final step: apply storage usage + mark completed. Extracted so
 	 * both the synchronous and background paths can call it.
 	 */
-	private async finishUpload(uploadId: string | RecordId, pendingUpload: any): Promise<any> {
+	private async finishUpload(uploadId: string | RecordId, pendingUpload: Upload): Promise<Upload> {
 		let appliedBytes = 0;
 		const revertFinalizingToPending = async () => {
 			await uploadRepository.updateWithUnset(
@@ -486,7 +490,9 @@ export class UploadController {
 				if (pendingUpload.size > 0 && appliedBytes > 0) {
 					try {
 						await fileStoreUsageController.subtractUsage(pendingUpload.owner_id, appliedBytes);
-					} catch { /* best-effort */ }
+					} catch {
+						/* best-effort */
+					}
 				}
 				await revertFinalizingToPending();
 			}
@@ -512,7 +518,12 @@ export class UploadController {
 
 		// Quick HeadObject check — more attempts for stores with write-commit lag
 		const retryAttempts = objectStore.requiresFinalizationRetry ? 3 : 1;
-		const headResult = await this.quickHeadObject(s3.bucket, pendingUpload.key, retryAttempts, 2000);
+		const headResult = await this.quickHeadObject(
+			s3.bucket,
+			pendingUpload.key,
+			retryAttempts,
+			2000
+		);
 
 		if (headResult) {
 			// File found — verify and complete synchronously
@@ -542,10 +553,7 @@ export class UploadController {
 			key: pendingUpload.key
 		});
 
-		const finalizingRow = await uploadRepository.casPendingToFinalizing(
-			uploadId,
-			new Date()
-		);
+		const finalizingRow = await uploadRepository.casPendingToFinalizing(uploadId, new Date());
 		if (!finalizingRow) {
 			const latest = await uploadRepository.findById(uploadId);
 			if (latest?.status === 'completed') return latest;

--- a/apps/syr/app/src/lib/services/object-store.ts
+++ b/apps/syr/app/src/lib/services/object-store.ts
@@ -10,7 +10,6 @@ import {
 	ListObjectsV2Command,
 	CreateBucketCommand,
 	PutBucketCorsCommand,
-	PutBucketPolicyCommand,
 	type PutObjectCommandInput,
 	type PutObjectCommandOutput,
 	type GetObjectCommandInput,
@@ -40,7 +39,8 @@ export abstract class ObjectStore {
 		try {
 			return await this.client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
 		} catch (err) {
-			const status = (err as any)?.$metadata?.httpStatusCode;
+			const status = (err as { $metadata?: { httpStatusCode?: number } })?.$metadata
+				?.httpStatusCode;
 			if (status === 404) return null;
 			throw err;
 		}

--- a/apps/syr/app/src/lib/stores/upload-queue.svelte.ts
+++ b/apps/syr/app/src/lib/stores/upload-queue.svelte.ts
@@ -93,7 +93,6 @@ async function processEntry(entry: InternalEntry) {
 	try {
 		// 1. Hash
 		entry.status = 'hashing';
-		entries = entries;
 		if (signal.aborted) throw new Error('Upload cancelled');
 		const buf = await file.arrayBuffer();
 		if (signal.aborted) throw new Error('Upload cancelled');
@@ -102,7 +101,6 @@ async function processEntry(entry: InternalEntry) {
 
 		// 2. Presign
 		entry.status = 'presigning';
-		entries = entries;
 		const presignRes = await fetch(api, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -122,16 +120,19 @@ async function processEntry(entry: InternalEntry) {
 		// 3. PUT with progress
 		entry.status = 'uploading';
 		entry.progress = 0;
-		entries = entries;
-		await putWithProgress(signedUrl, file, signal, (p) => {
-			entry.progress = p;
-			entries = entries;
-		}, checksumBase64);
+		await putWithProgress(
+			signedUrl,
+			file,
+			signal,
+			(p) => {
+				entry.progress = p;
+			},
+			checksumBase64
+		);
 
 		// 4. Finalize + poll
 		entry.status = 'finalizing';
 		entry.progress = 1;
-		entries = entries;
 		const completeBody = JSON.stringify({
 			did: uploadDid,
 			local_id: uploadLocalId,
@@ -168,7 +169,6 @@ async function processEntry(entry: InternalEntry) {
 		if (!completeRes.ok) throw new Error(`Failed to complete upload for ${file.name}`);
 
 		entry.status = 'completed';
-		entries = entries;
 		storageEvents.refresh();
 		opts.onFileCompleted?.();
 	} catch (err) {
@@ -178,7 +178,6 @@ async function processEntry(entry: InternalEntry) {
 			entry.status = 'failed';
 			entry.error = err instanceof Error ? err.message : 'Unknown error';
 		}
-		entries = entries;
 	} finally {
 		activeCount--;
 		drainQueue();
@@ -236,7 +235,6 @@ export function cancelUpload(id: string) {
 	if (!entry) return;
 	entry.status = 'cancelled';
 	entry.abort.abort();
-	entries = entries;
 }
 
 export function dismissUpload(id: string) {
@@ -245,9 +243,6 @@ export function dismissUpload(id: string) {
 
 export function dismissAll() {
 	entries = entries.filter(
-		(e) =>
-			e.status !== 'completed' &&
-			e.status !== 'failed' &&
-			e.status !== 'cancelled'
+		(e) => e.status !== 'completed' && e.status !== 'failed' && e.status !== 'cancelled'
 	);
 }

--- a/apps/syr/app/src/routes/+layout.svelte
+++ b/apps/syr/app/src/routes/+layout.svelte
@@ -37,7 +37,7 @@
 <Toaster />
 
 {#if uploadQueue.list.length > 0}
-	<div class="fixed bottom-4 right-4 z-50">
+	<div class="fixed right-4 bottom-4 z-50">
 		<UploadProgressToast />
 	</div>
 {/if}

--- a/apps/syr/app/src/routes/api/admin/media/+server.ts
+++ b/apps/syr/app/src/routes/api/admin/media/+server.ts
@@ -8,7 +8,7 @@ import {
 	recordIdFromDidAndLocal,
 	stringToRecordId
 } from '@syr-is/types';
-import { PutObjectCommand, HeadObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { userRepository } from '$lib/repositories/user.repository';
 import { uploadRepository } from '$lib/repositories/upload.repository';
@@ -215,9 +215,13 @@ export const PATCH: RequestHandler = async ({ request, locals }) => {
 		}
 		const result = await uploadController.completeUpload(uploadId);
 
-		if (result && 'status' in result && result.status === 'finalizing') {
+		if (result && 'message' in result) {
 			return json(
-				{ status: 'finalizing', message: result.message, meta: { timestamp: new Date().toISOString() } },
+				{
+					status: 'finalizing',
+					message: result.message,
+					meta: { timestamp: new Date().toISOString() }
+				},
 				{ status: 202 }
 			);
 		}

--- a/apps/syr/app/src/routes/api/uploads/+server.ts
+++ b/apps/syr/app/src/routes/api/uploads/+server.ts
@@ -175,7 +175,7 @@ export const PATCH: RequestHandler = async ({ request, locals }) => {
 		const result = await uploadController.completeUpload(uploadRecordId);
 
 		// Background finalization — tell client to poll
-		if (result && 'status' in result && result.status === 'finalizing') {
+		if (result && 'message' in result) {
 			return json(
 				{
 					status: 'finalizing',

--- a/apps/syr/app/src/routes/api/user/profile-asset/+server.ts
+++ b/apps/syr/app/src/routes/api/user/profile-asset/+server.ts
@@ -81,9 +81,7 @@ export const PATCH: RequestHandler = async ({ request, locals }) => {
 
 	// Derive URL from key + current S3_PUBLIC_URL config rather than the stored
 	// upload.url, which may have been written with a stale/wrong endpoint.
-	const currentUrl = upload.key
-		? `${s3.publicUrl}/${s3.bucket}/${upload.key}`
-		: upload.url;
+	const currentUrl = upload.key ? `${s3.publicUrl}/${s3.bucket}/${upload.key}` : upload.url;
 	const updates = body.role === 'avatar' ? { avatar_url: currentUrl } : { banner_url: currentUrl };
 
 	const profile = await profileRepository.mergeByUserId(user.id, updates);

--- a/packages/ts/crypto/package.json
+++ b/packages/ts/crypto/package.json
@@ -43,7 +43,7 @@
     "build:wasm:node": "cd ../../rust/syr-crypto-wasm && wasm-pack build --target nodejs --out-dir ../../ts/crypto/dist/wasm/node",
     "build:wasm:node:esm": "node scripts/generate-node-esm-wrapper.mjs",
     "dev": "tsc --watch --preserveWatchOutput",
-    "check": "tsc --noEmit",
+    "check": "pnpm run build:wasm && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "format": "prettier --write .",


### PR DESCRIPTION
Bundles the lint-debt the upload area accumulated through recent merges. Together: `pnpm --filter @syr-is/syr lint` 18 errors → 0, `pnpm --filter @syr-is/syr check` clean.

upload-queue.svelte.ts
  Holdover from Svelte 4 store-reactivity. Under Svelte 5 runes,
  `entries = $state<...>([])` is already a deep proxy — mutating
  `entry.status` / `entry.progress` on an element inside the array
  triggers subscribers without help. Self-assigning the array back to
  itself is a no-op the proxy noticed a frame earlier. Removed all 8
  no-op writes; the two remaining `entries = entries.filter(...)`
  assignments stay since those actually replace the array reference.

upload.controller.ts
  Replaced `(err as any)?.$metadata?.httpStatusCode` with the narrow
  `{ $metadata?: { httpStatusCode?: number } }` cast — same runtime
  shape. Typed three private `upload: any` / `pendingUpload: any`
  parameters as `Upload` (already imported from `@syr-is/types`); the
  controller was treating them opaque but every field read is on
  `Upload`. Tightening `finishUpload`'s return to `Promise<Upload>`
  surfaced a latent type bug at the two `completeUpload` call sites:
  the discriminator `result.status === 'finalizing'` was ambiguous
  because `Upload['status']` also includes 'finalizing'. Switched both
  callers to `'message' in result` — the property is unique to the
  pending-poll branch, so the narrow actually works. Pure type fix,
  no runtime change.

object-store.ts
  Removed unused `PutBucketPolicyCommand` import — left over from the
  raw-S3 policy path that 36b21fab replaced with minio-js. Same narrow
  `$metadata` cast.

api/admin/media/+server.ts
  Removed unused `HeadObjectCommand` / `DeleteObjectCommand` imports.

Plus the prettier reflow pre-commit's `prettier --check .` was flagging across 8 files in the upload area — whitespace only.

## Description

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / config / refactor / other

## Related Issues

Closes #

## Changes

-
-

## Testing

- [ ] Tested locally / in Docker
- [ ] Unit / integration tests pass

## Checklist

- [ ] Code follows project style (ESLint, Prettier)
- [ ] Self-reviewed
- [ ] Build passes (`pnpm build`)
