### PR TITLE
perf: batch media url mime type lookups to fix N+1 queries

### DIFF
--- a/apps/syr/app/src/lib/repositories/upload.repository.ts
+++ b/apps/syr/app/src/lib/repositories/upload.repository.ts
@@ -255,12 +255,13 @@ export class UploadRepository extends BaseRepository<Upload> {
 	 */
 	async findByIds(ids: RecordId[]): Promise<Upload[]> {
 		if (ids.length === 0) return [];
-		const result = await this.db.query<[Upload[]]>(`SELECT * FROM upload WHERE id IN $ids`, {
-			ids
-		});
+		const result = await this.db.query<[Upload[]]>(`SELECT * FROM $ids`, { ids });
 		const raw = result[0] ?? [];
 		const uploads: Upload[] = [];
 		for (const r of raw) {
+			// FROM $ids resolves each id against its own table, so re-assert the
+			// scoping the old `FROM upload` query gave us for free.
+			if (r?.id?.tb !== this.tableName) continue;
 			try {
 				uploads.push(this.validate(r));
 			} catch {

--- a/apps/syr/app/src/lib/repositories/upload.repository.ts
+++ b/apps/syr/app/src/lib/repositories/upload.repository.ts
@@ -249,6 +249,26 @@ export class UploadRepository extends BaseRepository<Upload> {
 		);
 		return result[0]?.[0]?.total ?? 0;
 	}
+
+	/**
+	 * Find multiple uploads by their IDs
+	 */
+	async findByIds(ids: RecordId[]): Promise<Upload[]> {
+		if (ids.length === 0) return [];
+		const result = await this.db.query<[Upload[]]>(`SELECT * FROM upload WHERE id IN $ids`, {
+			ids
+		});
+		const raw = result[0] ?? [];
+		const uploads: Upload[] = [];
+		for (const r of raw) {
+			try {
+				uploads.push(this.validate(r));
+			} catch {
+				// Skip individual invalid records to prevent failing the batch
+			}
+		}
+		return uploads;
+	}
 }
 
 export const uploadRepository = new UploadRepository();

--- a/apps/syr/app/src/lib/utils/post-media.server.ts
+++ b/apps/syr/app/src/lib/utils/post-media.server.ts
@@ -1,5 +1,6 @@
 import { recordIdFromDidAndLocal } from '@syr-is/types';
-import { uploadController } from '$lib/controllers/upload.controller';
+import { uploadRepository } from '$lib/repositories/upload.repository';
+import type { RecordId } from 'surrealdb';
 
 /**
  * Extract upload composite ID (DID + localId) from a media URL.
@@ -30,23 +31,44 @@ export interface MediaUrlMetadata {
 export async function resolveMediaUrlMetadata(mediaUrls: string[]): Promise<MediaUrlMetadata> {
 	const mimeTypes: Record<string, string> = {};
 	const filenames: Record<string, string> = {};
-	await Promise.all(
-		mediaUrls.map(async (url) => {
-			const ids = extractUploadRecordId(url);
-			if (ids) {
-				try {
-					const recordId = recordIdFromDidAndLocal('upload', ids.did, ids.localId);
-					const upload = await uploadController.getUpload(recordId);
-					if (upload) {
+
+	const uniqueUrls = [...new Set(mediaUrls)];
+	const recordIds: RecordId[] = [];
+	const urlByRecordId = new Map<string, string[]>();
+
+	for (const url of uniqueUrls) {
+		const ids = extractUploadRecordId(url);
+		if (ids) {
+			const recordId = recordIdFromDidAndLocal('upload', ids.did, ids.localId);
+			const ridStr = recordId.toString();
+
+			const urls = urlByRecordId.get(ridStr) || [];
+			if (urls.length === 0) {
+				recordIds.push(recordId);
+			}
+			urls.push(url);
+			urlByRecordId.set(ridStr, urls);
+		}
+	}
+
+	if (recordIds.length > 0) {
+		try {
+			const uploads = await uploadRepository.findByIds(recordIds);
+			for (const upload of uploads) {
+				const ridStr = upload.id.toString();
+				const mappedUrls = urlByRecordId.get(ridStr);
+				if (mappedUrls) {
+					for (const url of mappedUrls) {
 						mimeTypes[url] = upload.mime_type;
 						filenames[url] = upload.filename;
 					}
-				} catch {
-					// Skip if upload record not found
 				}
 			}
-		})
-	);
+		} catch {
+			// Skip if batch query fails
+		}
+	}
+
 	return { mimeTypes, filenames };
 }
 


### PR DESCRIPTION
## Description

Optimizes media MIME type and filename resolution on post listings by replacing individual database queries with a single batch lookup.

## Changes

- Added `findByIds` batch query method to `UploadRepository` to fetch multiple records in one query using `IN`.
- Refactored `resolveMediaUrlMetadata` in `post-media.server.ts` to deduplicate media URLs and fetch all metadata in a single batch request.

## Testing

- Tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved media metadata loading by retrieving upload information in batches.
  * Reduced redundant lookups when multiple media URLs reference the same upload.

* **Reliability**
  * Invalid or unavailable upload records no longer prevent other media metadata from being processed.
  * Empty upload lookup requests are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->